### PR TITLE
Efficient canvas update structure with asynchronous tokio backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ napi-derive = "1.1.0"
 
 cached = "0.23.0"
 cpal = "0.13.1"
+futures = "0.3.15"
 lazy_static = "1.4.0"
 ndarray = {version = "0.15.1", features = ["rayon", "approx"]}
 ndarray-stats = "0.5.0"
@@ -28,6 +29,7 @@ realfft = "2.0.1"
 rgb = "0.8.27"
 rustfft = "6.0.0"
 tiny-skia = "0.5.1"
+tokio = {version = "1.6.0", features = ["rt-multi-thread", "sync"]}
 
 [dependencies.approx]
 features = ["num-complex"]

--- a/native/backend/display.rs
+++ b/native/backend/display.rs
@@ -85,88 +85,19 @@ pub fn convert_spec_to_grey(
     unsafe { grey.assume_init() }
 }
 
-pub fn blend(
-    spec_img: &Vec<u8>,
-    wav_img: &Vec<u8>,
-    width: u32,
-    height: u32,
-    blend: f64,
-    eff_l_w: (u32, u32),
-) -> Vec<u8> {
-    assert!(0. < blend && blend < 1.);
-    let mut result = spec_img.clone();
-    let mut pixmap = PixmapMut::from_bytes(&mut result[..], width, height).unwrap();
-    // black
-    if blend < 0.5 && eff_l_w.1 > 0 {
-        let (left, width) = eff_l_w;
-        let rect = IntRect::from_xywh(left as i32, 0, width, height)
-            .unwrap()
-            .to_rect();
-        let mut paint = Paint::default();
-        paint.set_color_rgba8(0, 0, 0, (u8::MAX as f64 * (1. - 2. * blend)).round() as u8);
-        pixmap.fill_rect(rect, &paint, Transform::identity(), None);
-    }
-    {
-        let mut paint = PixmapPaint::default();
-        paint.opacity = (2. - 2. * blend).min(1.) as f32;
-        pixmap.draw_pixmap(
-            0,
-            0,
-            PixmapRef::from_bytes(wav_img, width, height).unwrap(),
-            &paint,
-            Transform::identity(),
-            None,
-        );
-    }
-    result
-}
-
-pub fn draw_blended_spec_wav(
-    entire_spec_grey: ArrayView2<f32>,
-    wav_slice: ArrayView1<f32>,
-    width: u32,
-    height: u32,
-    grey_left_width: Option<(usize, usize)>,
-    amp_range: (f32, f32),
-    fast_resize: bool,
-    blend: f64,
-) -> Vec<u8> {
-    // spec
-    let mut result = if blend > 0. {
-        colorize_grey_with_size(
-            entire_spec_grey,
-            width,
-            height,
-            fast_resize,
-            grey_left_width,
-        )
-    } else {
-        vec![0u8; width as usize * height as usize * 4]
-    };
-
-    let mut pixmap = PixmapMut::from_bytes(&mut result[..], width, height).unwrap();
-
-    if blend < 1. {
-        // black
-        if blend < 0.5 {
-            let rect = IntRect::from_xywh(0, 0, width, height).unwrap().to_rect();
-            let mut paint = Paint::default();
-            paint.set_color_rgba8(0, 0, 0, (u8::MAX as f64 * (1. - 2. * blend)).round() as u8);
-            pixmap.fill_rect(rect, &paint, Transform::identity(), None);
+pub fn calc_effective_w(i_w: isize, width: usize, total_width: usize) -> Option<(usize, usize)> {
+    if i_w >= total_width as isize {
+        None
+    } else if i_w < 0 {
+        let i_right = width as isize + i_w;
+        if i_right <= 0 {
+            None
+        } else {
+            Some((0, (i_right as usize).min(total_width)))
         }
-
-        let alpha = (u8::MAX as f64 * (2. - 2. * blend).min(1.)).round() as u8;
-        // wave
-        draw_wav_to(
-            pixmap.data_mut(),
-            wav_slice,
-            width,
-            height,
-            amp_range,
-            Some(alpha),
-        );
+    } else {
+        Some((i_w as usize, width.min(total_width - i_w as usize)))
     }
-    result
 }
 
 pub fn colorize_grey_with_size(
@@ -205,72 +136,6 @@ pub fn colorize_grey_with_size(
         })
         .collect()
     // println!("drawing spec: {:?}", start.elapsed());
-}
-
-#[cached(size = 3)]
-pub fn create_freq_axis(freq_scale: FreqScale, sr: u32, max_ticks: u32) -> Vec<(f64, f64)> {
-    fn coarse_band(fine_band: f64) -> f64 {
-        if fine_band <= 100. {
-            100.
-        } else if fine_band <= 200. {
-            200.
-        } else if fine_band <= 500. {
-            500.
-        } else {
-            (fine_band / 1000.).ceil() * 1000.
-        }
-    }
-
-    let mut result = Vec::with_capacity(max_ticks as usize);
-    result.push((1., 0.));
-    let max_freq = sr as f64 / 2.;
-
-    if max_ticks >= 3 {
-        match freq_scale {
-            FreqScale::Mel if max_freq > 1000. => {
-                let max_mel = mel::from_hz(max_freq);
-                let mel_1k = mel::MIN_LOG_MEL as f64;
-                let fine_band_mel = max_mel / (max_ticks as f64 - 1.);
-                if max_ticks >= 4 && fine_band_mel <= mel_1k / 2. {
-                    // divide [0, 1kHz] region
-                    let fine_band = mel::to_hz(fine_band_mel);
-                    let band = coarse_band(fine_band);
-                    let mut freq = band;
-                    let max_minus_band = 1000. - fine_band + 1.;
-                    while freq < max_minus_band {
-                        result.push((1. - mel::from_hz(freq) / max_mel, freq));
-                        freq += band;
-                    }
-                }
-                result.push((1. - mel_1k / max_mel, 1000.));
-                if max_ticks >= 4 {
-                    // divide [1kHz, max_freq] region
-                    let ratio_step =
-                        2u32.pow((fine_band_mel / mel::MEL_DIFF_2K_1K).ceil().max(1.) as u32);
-                    let mut freq = ratio_step as f64 * 1000.;
-                    let mut mel_f = mel::from_hz(freq);
-                    let max_mel_minus_band = max_mel - fine_band_mel + 0.01;
-                    while mel_f < max_mel_minus_band {
-                        result.push((1. - mel_f / max_mel, freq));
-                        freq *= ratio_step as f64;
-                        mel_f = mel::from_hz(freq);
-                    }
-                }
-            }
-            _ => {
-                let fine_band = max_freq / (max_ticks as f64 - 1.);
-                let band = coarse_band(fine_band);
-                let mut freq = band;
-                while freq < max_freq - fine_band + 1. {
-                    result.push((1. - freq / max_freq, freq));
-                    freq += band;
-                }
-            }
-        }
-    }
-
-    result.push((0., max_freq));
-    result
 }
 
 fn draw_wav_directly(wav_avg: &[f32], pixmap: &mut PixmapMut, paint: &Paint) {
@@ -387,6 +252,156 @@ pub fn draw_wav_to(
         draw_wav_directly(&wav_avg[..], &mut pixmap, &paint);
     }
     // println!("drawing wav: {:?}", start.elapsed());
+}
+
+pub fn draw_blended_spec_wav(
+    entire_spec_grey: ArrayView2<f32>,
+    wav_slice: ArrayView1<f32>,
+    width: u32,
+    height: u32,
+    grey_left_width: Option<(usize, usize)>,
+    amp_range: (f32, f32),
+    fast_resize: bool,
+    blend: f64,
+) -> Vec<u8> {
+    // spec
+    let mut result = if blend > 0. {
+        colorize_grey_with_size(
+            entire_spec_grey,
+            width,
+            height,
+            fast_resize,
+            grey_left_width,
+        )
+    } else {
+        vec![0u8; width as usize * height as usize * 4]
+    };
+
+    let mut pixmap = PixmapMut::from_bytes(&mut result[..], width, height).unwrap();
+
+    if blend < 1. {
+        // black
+        if blend < 0.5 {
+            let rect = IntRect::from_xywh(0, 0, width, height).unwrap().to_rect();
+            let mut paint = Paint::default();
+            paint.set_color_rgba8(0, 0, 0, (u8::MAX as f64 * (1. - 2. * blend)).round() as u8);
+            pixmap.fill_rect(rect, &paint, Transform::identity(), None);
+        }
+
+        let alpha = (u8::MAX as f64 * (2. - 2. * blend).min(1.)).round() as u8;
+        // wave
+        draw_wav_to(
+            pixmap.data_mut(),
+            wav_slice,
+            width,
+            height,
+            amp_range,
+            Some(alpha),
+        );
+    }
+    result
+}
+
+pub fn blend(
+    spec_img: &Vec<u8>,
+    wav_img: &Vec<u8>,
+    width: u32,
+    height: u32,
+    blend: f64,
+    eff_l_w: (u32, u32),
+) -> Vec<u8> {
+    assert!(0. < blend && blend < 1.);
+    let mut result = spec_img.clone();
+    let mut pixmap = PixmapMut::from_bytes(&mut result[..], width, height).unwrap();
+    // black
+    if blend < 0.5 && eff_l_w.1 > 0 {
+        let (left, width) = eff_l_w;
+        let rect = IntRect::from_xywh(left as i32, 0, width, height)
+            .unwrap()
+            .to_rect();
+        let mut paint = Paint::default();
+        paint.set_color_rgba8(0, 0, 0, (u8::MAX as f64 * (1. - 2. * blend)).round() as u8);
+        pixmap.fill_rect(rect, &paint, Transform::identity(), None);
+    }
+    {
+        let mut paint = PixmapPaint::default();
+        paint.opacity = (2. - 2. * blend).min(1.) as f32;
+        pixmap.draw_pixmap(
+            0,
+            0,
+            PixmapRef::from_bytes(wav_img, width, height).unwrap(),
+            &paint,
+            Transform::identity(),
+            None,
+        );
+    }
+    result
+}
+
+#[cached(size = 3)]
+pub fn create_freq_axis(freq_scale: FreqScale, sr: u32, max_ticks: u32) -> Vec<(f64, f64)> {
+    let coarse_band = |fine_band: f64| {
+        if fine_band <= 100. {
+            100.
+        } else if fine_band <= 200. {
+            200.
+        } else if fine_band <= 500. {
+            500.
+        } else {
+            (fine_band / 1000.).ceil() * 1000.
+        }
+    };
+
+    let mut result = Vec::with_capacity(max_ticks as usize);
+    result.push((1., 0.));
+    let max_freq = sr as f64 / 2.;
+
+    if max_ticks >= 3 {
+        match freq_scale {
+            FreqScale::Mel if max_freq > 1000. => {
+                let max_mel = mel::from_hz(max_freq);
+                let mel_1k = mel::MIN_LOG_MEL as f64;
+                let fine_band_mel = max_mel / (max_ticks as f64 - 1.);
+                if max_ticks >= 4 && fine_band_mel <= mel_1k / 2. {
+                    // divide [0, 1kHz] region
+                    let fine_band = mel::to_hz(fine_band_mel);
+                    let band = coarse_band(fine_band);
+                    let mut freq = band;
+                    let max_minus_band = 1000. - fine_band + 1.;
+                    while freq < max_minus_band {
+                        result.push((1. - mel::from_hz(freq) / max_mel, freq));
+                        freq += band;
+                    }
+                }
+                result.push((1. - mel_1k / max_mel, 1000.));
+                if max_ticks >= 4 {
+                    // divide [1kHz, max_freq] region
+                    let ratio_step =
+                        2u32.pow((fine_band_mel / mel::MEL_DIFF_2K_1K).ceil().max(1.) as u32);
+                    let mut freq = ratio_step as f64 * 1000.;
+                    let mut mel_f = mel::from_hz(freq);
+                    let max_mel_minus_band = max_mel - fine_band_mel + 0.01;
+                    while mel_f < max_mel_minus_band {
+                        result.push((1. - mel_f / max_mel, freq));
+                        freq *= ratio_step as f64;
+                        mel_f = mel::from_hz(freq);
+                    }
+                }
+            }
+            _ => {
+                let fine_band = max_freq / (max_ticks as f64 - 1.);
+                let band = coarse_band(fine_band);
+                let mut freq = band;
+                while freq < max_freq - fine_band + 1. {
+                    result.push((1. - freq / max_freq, freq));
+                    freq += band;
+                }
+            }
+        }
+    }
+
+    result.push((0., max_freq));
+    result
 }
 
 pub fn get_colormap_rgba() -> Vec<u8> {

--- a/native/backend/display.rs
+++ b/native/backend/display.rs
@@ -91,13 +91,17 @@ pub fn blend(
     width: u32,
     height: u32,
     blend: f64,
+    eff_l_w: (u32, u32),
 ) -> Vec<u8> {
     assert!(0. < blend && blend < 1.);
     let mut result = spec_img.clone();
     let mut pixmap = PixmapMut::from_bytes(&mut result[..], width, height).unwrap();
     // black
-    if blend < 0.5 {
-        let rect = IntRect::from_xywh(0, 0, width, height).unwrap().to_rect();
+    if blend < 0.5 && eff_l_w.1 > 0 {
+        let (left, width) = eff_l_w;
+        let rect = IntRect::from_xywh(left as i32, 0, width, height)
+            .unwrap()
+            .to_rect();
         let mut paint = Paint::default();
         paint.set_color_rgba8(0, 0, 0, (u8::MAX as f64 * (1. - 2. * blend)).round() as u8);
         pixmap.fill_rect(rect, &paint, Transform::identity(), None);

--- a/native/backend/display.rs
+++ b/native/backend/display.rs
@@ -86,14 +86,14 @@ pub fn convert_spec_to_grey(
 }
 
 pub fn blend(
-    spec_grey: &Vec<u8>,
+    spec_img: &Vec<u8>,
     wav_img: &Vec<u8>,
     width: u32,
     height: u32,
     blend: f64,
 ) -> Vec<u8> {
     assert!(0. < blend && blend < 1.);
-    let mut result = spec_grey.clone();
+    let mut result = spec_img.clone();
     let mut pixmap = PixmapMut::from_bytes(&mut result[..], width, height).unwrap();
     // black
     if blend < 0.5 {

--- a/native/img_mgr.rs
+++ b/native/img_mgr.rs
@@ -1,0 +1,501 @@
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+use std::task::{Context, Poll};
+
+use futures::task;
+use lazy_static::{initialize, lazy_static};
+use ndarray::{Array3, Axis, Slice};
+use rayon::prelude::*;
+use tokio::{
+    runtime::{Builder, Runtime},
+    sync::mpsc::{self, Receiver, Sender},
+    task::JoinHandle,
+};
+
+use crate::backend::{
+    display::{self, calc_effective_w},
+    utils, DrawOption, DrawOptionForWav, IdChArr, IdChMap, IdChVec, ImageKind,
+};
+use crate::TM;
+
+type Images = IdChMap<Vec<u8>>;
+type ArcImgCaches = Arc<Mutex<IdChMap<Array3<u8>>>>;
+type GuardImgCaches<'a> = MutexGuard<'a, IdChMap<Array3<u8>>>;
+
+lazy_static! {
+    static ref RUNTIME: Runtime = Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_name("thesia-tokio")
+        .build()
+        .unwrap();
+}
+
+static mut MSG_TX: Option<Sender<ImgMsg>> = None;
+static mut IMG_RX: Option<Receiver<Images>> = None;
+
+#[derive(Clone, PartialEq)]
+pub struct DrawParams {
+    sec: f64,
+    width: u32,
+    option: DrawOption,
+    opt_for_wav: DrawOptionForWav,
+    blend: f64,
+}
+
+impl DrawParams {
+    pub fn new(
+        sec: f64,
+        width: u32,
+        option: DrawOption,
+        opt_for_wav: DrawOptionForWav,
+        blend: f64,
+    ) -> Self {
+        DrawParams {
+            sec,
+            width,
+            option,
+            opt_for_wav,
+            blend,
+        }
+    }
+}
+
+impl Default for DrawParams {
+    fn default() -> Self {
+        DrawParams {
+            sec: 0.,
+            width: 1,
+            option: DrawOption {
+                px_per_sec: 0.,
+                height: 1,
+            },
+            opt_for_wav: DrawOptionForWav {
+                amp_range: (-1., 1.),
+            },
+            blend: 1.,
+        }
+    }
+}
+
+pub enum ImgMsg {
+    Draw((IdChVec, DrawParams)),
+    Remove(IdChVec),
+}
+
+#[derive(Default)]
+struct CategorizedIdChVec {
+    use_caches: IdChVec,
+    need_parts: IdChVec,
+    need_new_caches: IdChVec,
+}
+
+pub fn send(msg: ImgMsg) {
+    let img_mngr_tx = unsafe { MSG_TX.clone().unwrap() };
+    if let Err(e) = img_mngr_tx.blocking_send(msg) {
+        panic!("DRAW_TX error: {}", e);
+    }
+}
+
+pub fn recv() -> Option<Images> {
+    let waker = task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    let img_rx = unsafe { IMG_RX.as_mut().unwrap() };
+    let mut opt_images: Option<Images> = None;
+    while let Poll::Ready(Some(x)) = img_rx.poll_recv(&mut cx) {
+        opt_images = Some(x);
+    }
+
+    opt_images
+}
+
+fn crop_caches(
+    images: &GuardImgCaches,
+    id_ch_tuples: &IdChArr,
+    sec: f64,
+    width: u32,
+    option: &DrawOption,
+) -> (Images, IdChMap<(u32, u32)>) {
+    // let start = Instant::now();
+    let mut imgs = Images::new();
+    let mut eff_l_w_map = IdChMap::new();
+    let vec: Vec<_> = id_ch_tuples
+        .par_iter()
+        .filter_map(|tup| {
+            let image = images.get(&tup)?;
+            let total_width = image.len() / 4 / option.height as usize;
+            let i_w = (sec * option.px_per_sec) as isize;
+            let (i_w_eff, width_eff) = match calc_effective_w(i_w, width as usize, total_width) {
+                Some((i, w)) => (i as isize, w as isize),
+                None => {
+                    return Some((
+                        *tup,
+                        (
+                            vec![0u8; width as usize * option.height as usize * 4],
+                            (0, 0),
+                        ),
+                    ));
+                }
+            };
+            let img_slice = image.slice_axis(Axis(1), Slice::from(i_w_eff..i_w_eff + width_eff));
+
+            let pad_left = (-i_w.min(0)) as usize;
+            let pad_right = width as usize - width_eff as usize - pad_left;
+            if pad_left + pad_right == 0 {
+                Some((*tup, (img_slice.to_owned().into_raw_vec(), (0, width))))
+            } else {
+                let arr = utils::pad(
+                    img_slice,
+                    (pad_left, pad_right),
+                    Axis(1),
+                    utils::PadMode::Constant(0),
+                );
+                Some((
+                    *tup,
+                    (arr.into_raw_vec(), (pad_left as u32, width_eff as u32)),
+                ))
+            }
+        })
+        .collect();
+    eff_l_w_map.extend(vec.iter().map(|(k, (_, eff_l_w))| (*k, *eff_l_w)));
+    imgs.extend(vec.into_iter().map(|(k, (img, _))| (k, img)));
+    // println!("crop: {:?}", start.elapsed());
+    (imgs, eff_l_w_map)
+}
+
+fn categorize_id_ch(
+    id_ch_tuples: IdChVec,
+    total_widths: &IdChMap<u32>,
+    spec_caches: &GuardImgCaches,
+    wav_caches: &GuardImgCaches,
+    option: &DrawOption,
+    blend: f64,
+) -> (CategorizedIdChVec, CategorizedIdChVec, IdChVec) {
+    let categorize = |images: &GuardImgCaches| {
+        if option.height <= display::MAX_SIZE {
+            let mut result = CategorizedIdChVec::default();
+            for tup in id_ch_tuples.iter() {
+                let not_long_w = *total_widths.get(tup).unwrap() <= display::MAX_SIZE;
+                match (images.contains_key(tup), not_long_w) {
+                    (true, _) => result.use_caches.push(*tup),
+                    (false, true) => {
+                        result.need_parts.push(*tup);
+                        result.need_new_caches.push(*tup);
+                    }
+                    (false, false) => {
+                        result.need_parts.push(*tup);
+                    }
+                }
+            }
+            result
+        } else {
+            CategorizedIdChVec {
+                use_caches: Vec::new(),
+                need_parts: id_ch_tuples.to_owned(),
+                need_new_caches: Vec::new(),
+            }
+        }
+    };
+    let cat_by_spec = if blend > 0. {
+        categorize(spec_caches)
+    } else {
+        CategorizedIdChVec::default()
+    };
+    let mut cat_by_wav = if blend < 1. {
+        categorize(wav_caches)
+    } else {
+        CategorizedIdChVec::default()
+    };
+    let mut need_wav_parts_only = Vec::new();
+    {
+        let (mut i, mut j) = (0, 0);
+        while i < cat_by_spec.use_caches.len() && j < cat_by_wav.use_caches.len() {
+            if cat_by_spec.use_caches[i] == cat_by_wav.use_caches[j] {
+                i += 1;
+                j += 1;
+            } else {
+                need_wav_parts_only.push(cat_by_spec.use_caches[i]);
+                i += 1;
+                let index = cat_by_wav
+                    .need_parts
+                    .iter()
+                    .position(|x| *x == cat_by_spec.use_caches[i])
+                    .unwrap();
+                cat_by_wav.need_parts.remove(index);
+            }
+        }
+    }
+    assert!(
+        cat_by_spec.need_parts.len() == 0
+            || cat_by_wav.need_parts.len() == 0
+            || cat_by_spec.need_parts.len() == cat_by_wav.need_parts.len()
+    );
+    (cat_by_spec, cat_by_wav, need_wav_parts_only)
+}
+
+#[inline]
+fn blend_imgs(
+    spec_imgs: Images,
+    wav_imgs: Images,
+    eff_l_w_map: IdChMap<(u32, u32)>,
+    width: u32,
+    height: u32,
+    blend: f64,
+) -> Images {
+    if blend == 1. {
+        spec_imgs
+    } else if blend == 0. {
+        wav_imgs
+    } else {
+        spec_imgs
+            .par_iter()
+            .filter_map(|(k, spec_img)| {
+                let wav_img = wav_imgs.get(k)?;
+                let eff_l_w = eff_l_w_map.get(k).cloned().unwrap_or((0, 0));
+                let img = display::blend(spec_img, wav_img, width, height, blend, eff_l_w);
+                Some((*k, img))
+            })
+            .collect()
+    }
+}
+
+async fn draw_imgs(
+    id_ch_tuples: IdChVec,
+    params: Arc<RwLock<DrawParams>>,
+    spec_caches: ArcImgCaches,
+    wav_caches: ArcImgCaches,
+    img_tx: Sender<Images>,
+) {
+    let params_backup = params.read().unwrap().clone();
+    let DrawParams {
+        sec,
+        width,
+        option,
+        opt_for_wav,
+        blend,
+    } = params_backup;
+    let (total_widths, cat_by_spec, cat_by_wav, blended_imgs) = {
+        let tm = TM.read().unwrap();
+        let id_ch_tuples: IdChVec = id_ch_tuples.into_iter().filter(|x| tm.exists(x)).collect();
+        let mut total_widths = IdChMap::<u32>::with_capacity(id_ch_tuples.len());
+        total_widths.extend(id_ch_tuples.iter().map(|&(id, ch)| {
+            let width = tm.tracks.get(&id).unwrap().calc_width(option.px_per_sec);
+            ((id, ch), width)
+        }));
+
+        let spec_caches_lock = spec_caches.lock().unwrap();
+        let wav_caches_lock = wav_caches.lock().unwrap();
+        let (cat_by_spec, cat_by_wav, need_wav_parts_only) = categorize_id_ch(
+            id_ch_tuples,
+            &total_widths,
+            &spec_caches_lock,
+            &wav_caches_lock,
+            &option,
+            blend,
+        );
+
+        // crop image cache
+        let (spec_imgs, eff_l_w_map) = if !cat_by_spec.use_caches.is_empty() {
+            crop_caches(
+                &spec_caches_lock,
+                &cat_by_spec.use_caches[..],
+                sec,
+                width,
+                &option,
+            )
+        } else {
+            (Images::new(), IdChMap::new())
+        };
+        let mut wav_imgs = if !cat_by_wav.use_caches.is_empty() {
+            crop_caches(
+                &wav_caches_lock,
+                &cat_by_wav.use_caches[..],
+                sec,
+                width,
+                &option,
+            )
+            .0
+        } else {
+            IdChMap::new()
+        };
+        if !need_wav_parts_only.is_empty() {
+            wav_imgs.extend(tm.get_part_imgs(
+                &need_wav_parts_only[..],
+                sec,
+                width,
+                option,
+                opt_for_wav,
+                0.,
+                None,
+            ));
+        };
+        (
+            total_widths,
+            cat_by_spec,
+            cat_by_wav,
+            blend_imgs(
+                spec_imgs,
+                wav_imgs,
+                eff_l_w_map,
+                width,
+                option.height,
+                blend,
+            ),
+        )
+    };
+    if !blended_imgs.is_empty() {
+        // println!("send cached images");
+        img_tx.send(blended_imgs).await.unwrap();
+    }
+    if *params.read().unwrap() != params_backup {
+        return;
+    }
+
+    // draw part
+    let blended_imgs = {
+        let tm = TM.read().unwrap();
+        if !cat_by_spec.need_parts.is_empty() {
+            let fast_resize_vec = if option.height <= display::MAX_SIZE {
+                Some(
+                    cat_by_spec
+                        .need_parts
+                        .iter()
+                        .map(|tup| *total_widths.get(tup).unwrap() <= display::MAX_SIZE)
+                        .collect(),
+                )
+            } else {
+                None
+            };
+            tm.get_part_imgs(
+                &cat_by_spec.need_parts[..],
+                sec,
+                width,
+                option,
+                opt_for_wav,
+                blend,
+                fast_resize_vec,
+            )
+        } else {
+            IdChMap::new()
+        }
+    };
+    if !blended_imgs.is_empty() {
+        // println!("send part images");
+        img_tx.send(blended_imgs).await.unwrap();
+    }
+    if *params.read().unwrap() != params_backup {
+        return;
+    }
+
+    let blended_imgs = {
+        let tm = TM.read().unwrap();
+        let mut spec_caches_lock = spec_caches.lock().unwrap();
+        let mut wav_caches_lock = wav_caches.lock().unwrap();
+        let (spec_imgs, eff_l_w_map) = if !cat_by_spec.need_new_caches.is_empty() {
+            spec_caches_lock.extend(tm.get_entire_imgs(
+                &cat_by_spec.need_new_caches[..],
+                option,
+                ImageKind::Spec,
+            ));
+            crop_caches(
+                &spec_caches_lock,
+                &cat_by_spec.need_new_caches[..],
+                sec,
+                width,
+                &option,
+            )
+        } else {
+            (Images::new(), IdChMap::new())
+        };
+        let wav_imgs = if !cat_by_wav.need_new_caches.is_empty() {
+            wav_caches_lock.extend(tm.get_entire_imgs(
+                &cat_by_wav.need_new_caches[..],
+                option,
+                ImageKind::Wav(opt_for_wav),
+            ));
+            crop_caches(
+                &wav_caches_lock,
+                &cat_by_wav.need_new_caches[..],
+                sec,
+                width,
+                &option,
+            )
+            .0
+        } else {
+            IdChMap::new()
+        };
+        blend_imgs(
+            spec_imgs,
+            wav_imgs,
+            eff_l_w_map,
+            width,
+            option.height,
+            blend,
+        )
+    };
+    if !blended_imgs.is_empty() {
+        // println!("send new cached images");
+        img_tx.send(blended_imgs).await.unwrap();
+    }
+}
+
+async fn main_loop(mut msg_rx: Receiver<ImgMsg>, img_tx: Sender<Images>) {
+    let spec_caches = Arc::new(Mutex::new(IdChMap::new()));
+    let wav_caches = Arc::new(Mutex::new(IdChMap::new()));
+    let prev_params = Arc::new(RwLock::new(DrawParams::default()));
+    let mut task_handle: Option<JoinHandle<()>> = None;
+    while let Some(msg) = msg_rx.recv().await {
+        match msg {
+            ImgMsg::Draw((id_ch_tuples, draw_params)) => {
+                {
+                    let mut prev_params_write = prev_params.write().unwrap();
+                    if let Some(prev_task) = task_handle.take() {
+                        prev_task.abort();
+                    }
+                    // if draw_params != *prev_params_write {
+                    //     let waker = task::noop_waker();
+                    //     let mut cx = Context::from_waker(&waker);
+                    //     let img_rx = unsafe { IMG_RX.as_mut().unwrap() };
+                    //     while let Poll::Ready(Some(_)) = img_rx.poll_recv(&mut cx) {}
+                    // }
+                    if draw_params.option != prev_params_write.option {
+                        spec_caches.lock().unwrap().clear();
+                        wav_caches.lock().unwrap().clear();
+                    } else if draw_params.opt_for_wav != prev_params_write.opt_for_wav {
+                        wav_caches.lock().unwrap().clear();
+                    }
+                    *prev_params_write = draw_params;
+                }
+                task_handle = Some(RUNTIME.spawn(draw_imgs(
+                    id_ch_tuples,
+                    Arc::clone(&prev_params),
+                    Arc::clone(&spec_caches),
+                    Arc::clone(&wav_caches),
+                    img_tx.clone(),
+                )));
+            }
+            ImgMsg::Remove(id_ch_tuples) => {
+                if let Some(prev_task) = task_handle.take() {
+                    prev_task.await.ok();
+                }
+                let mut spec_caches = spec_caches.lock().unwrap();
+                let mut wav_caches = wav_caches.lock().unwrap();
+                for tup in id_ch_tuples.iter() {
+                    spec_caches.remove(tup);
+                    wav_caches.remove(tup);
+                }
+            }
+        }
+    }
+}
+
+pub fn spawn_runtime() {
+    initialize(&RUNTIME);
+
+    let (msg_tx, msg_rx) = mpsc::channel::<ImgMsg>(60);
+    let (img_tx, img_rx) = mpsc::channel(60);
+    unsafe {
+        MSG_TX = Some(msg_tx);
+        IMG_RX = Some(img_rx);
+    }
+    RUNTIME.spawn(main_loop(msg_rx, img_tx));
+}

--- a/native/lib.rs
+++ b/native/lib.rs
@@ -1,27 +1,19 @@
 use std::convert::TryInto;
-use std::sync::{Arc, Mutex, MutexGuard, RwLock};
-use std::task::{Context, Poll};
+use std::sync::{Arc, RwLock};
 
+use lazy_static::{initialize, lazy_static};
 use napi::{
     CallContext, ContextlessResult, Env, JsBuffer, JsNumber, JsObject, JsString, JsUndefined,
     Result as JsResult,
 };
 use napi_derive::*;
 
-use futures::task;
-use lazy_static::{initialize, lazy_static};
-use ndarray::{Array3, Axis, Slice};
-use rayon::prelude::*;
-use tokio::{
-    runtime::{Builder, Runtime},
-    sync::mpsc::{self, Receiver, Sender},
-    task::JoinHandle,
-};
-
 mod backend;
+mod img_mgr;
 mod napi_utils;
 
 use backend::*;
+use img_mgr::{DrawParams, ImgMsg};
 use napi_utils::*;
 
 #[cfg(all(unix, not(target_env = "musl"), not(target_arch = "aarch64")))]
@@ -33,57 +25,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 lazy_static! {
-    static ref TM: RwLock<TrackManager> = RwLock::new(TrackManager::new());
-    static ref RUNTIME: Runtime = Builder::new_multi_thread()
-        .worker_threads(2)
-        .thread_name("thesia-tokio")
-        .build()
-        .unwrap();
-}
-
-static mut IMG_MNGR_TX: Option<Sender<ImgMsg>> = None;
-static mut IMG_RX: Option<Receiver<Images>> = None;
-
-type Images = IdChMap<Vec<u8>>;
-type ArcImgCaches = Arc<Mutex<IdChMap<Array3<u8>>>>;
-type GuardImgCaches<'a> = MutexGuard<'a, IdChMap<Array3<u8>>>;
-
-#[derive(Clone, PartialEq)]
-struct DrawParams {
-    sec: f64,
-    width: u32,
-    option: DrawOption,
-    opt_for_wav: DrawOptionForWav,
-    blend: f64,
-}
-
-impl Default for DrawParams {
-    fn default() -> Self {
-        DrawParams {
-            sec: 0.,
-            width: 1,
-            option: DrawOption {
-                px_per_sec: 0.,
-                height: 1,
-            },
-            opt_for_wav: DrawOptionForWav {
-                amp_range: (-1., 1.),
-            },
-            blend: 1.,
-        }
-    }
-}
-
-enum ImgMsg {
-    Draw((IdChVec, DrawParams)),
-    Remove(IdChVec),
-}
-
-#[derive(Default)]
-struct CategorizedIdChVec {
-    use_caches: IdChVec,
-    need_parts: IdChVec,
-    need_new_caches: IdChVec,
+    static ref TM: Arc<RwLock<TrackManager>> = Arc::new(RwLock::new(TrackManager::new()));
 }
 
 #[js_function(2)]
@@ -114,11 +56,7 @@ fn remove_tracks(ctx: CallContext) -> JsResult<JsUndefined> {
     assert!(track_ids.len() > 0);
 
     let mut tm = TM.write().unwrap();
-    let img_mngr_tx = unsafe { IMG_MNGR_TX.clone().unwrap() };
-    if let Err(e) = img_mngr_tx.blocking_send(ImgMsg::Remove(tm.id_ch_tuples_from(&track_ids[..])))
-    {
-        panic!("DRAW_TX error: {}", e);
-    }
+    img_mgr::send(ImgMsg::Remove(tm.id_ch_tuples_from(&track_ids[..])));
     tm.remove_tracks(&track_ids[..]);
     ctx.env.get_undefined()
 }
@@ -131,10 +69,7 @@ fn apply_track_list_changes(env: Env) -> ContextlessResult<JsObject> {
         tm.id_ch_tuples_from(&updated_ids)
     };
 
-    let img_mngr_tx = unsafe { IMG_MNGR_TX.clone().unwrap() };
-    if let Err(e) = img_mngr_tx.blocking_send(ImgMsg::Remove(id_ch_tuples.clone())) {
-        panic!("DRAW_TX error: {}", e);
-    }
+    img_mgr::send(ImgMsg::Remove(id_ch_tuples.clone()));
     convert_id_ch_vec_to_jsarr(&env, id_ch_tuples.iter(), id_ch_tuples.len()).map(|x| Some(x))
 }
 
@@ -155,35 +90,17 @@ fn set_img_state(ctx: CallContext) -> JsResult<JsUndefined> {
     assert!(option.height >= 1);
     assert!(opt_for_wav.amp_range.0 <= opt_for_wav.amp_range.1);
 
-    let img_mngr_tx = unsafe { IMG_MNGR_TX.clone().unwrap() };
-    if let Err(e) = img_mngr_tx.blocking_send(ImgMsg::Draw((
+    img_mgr::send(ImgMsg::Draw((
         id_ch_tuples,
-        DrawParams {
-            sec,
-            width,
-            option,
-            opt_for_wav,
-            blend,
-        },
-    ))) {
-        panic!("DRAW_TX error: {}", e);
-    }
+        DrawParams::new(sec, width, option, opt_for_wav, blend),
+    )));
     ctx.env.get_undefined()
 }
 
 #[contextless_function]
 fn get_images(env: Env) -> ContextlessResult<JsObject> {
-    let waker = task::noop_waker();
-    let mut cx = Context::from_waker(&waker);
-
-    let img_rx = unsafe { IMG_RX.as_mut().unwrap() };
-    let mut opt_images: Option<Images> = None;
-    while let Poll::Ready(Some(x)) = img_rx.poll_recv(&mut cx) {
-        opt_images = Some(x);
-    }
-
     let mut result = env.create_object()?;
-    if let Some(images) = opt_images {
+    if let Some(images) = img_mgr::recv() {
         for ((id, ch), im) in images.into_iter() {
             let name = format!("{}_{}", id, ch);
             let buf = env.create_buffer_with_data(im)?.into_raw();
@@ -303,379 +220,10 @@ fn get_colormap(env: Env) -> ContextlessResult<JsBuffer> {
         .map(|x| Some(x.into_raw()))
 }
 
-fn _crop_caches(
-    images: &GuardImgCaches,
-    id_ch_tuples: &IdChArr,
-    sec: f64,
-    width: u32,
-    option: &DrawOption,
-) -> (Images, IdChMap<(u32, u32)>) {
-    // let start = Instant::now();
-    let mut imgs = Images::new();
-    let mut eff_l_w_map = IdChMap::new();
-    let vec: Vec<_> = id_ch_tuples
-        .par_iter()
-        .filter_map(|tup| {
-            let image = images.get(&tup)?;
-            let total_width = image.len() / 4 / option.height as usize;
-            let i_w = (sec * option.px_per_sec) as isize;
-            let (i_w_eff, width_eff) = match calc_effective_w(i_w, width as usize, total_width) {
-                Some((i, w)) => (i as isize, w as isize),
-                None => {
-                    return Some((
-                        *tup,
-                        (
-                            vec![0u8; width as usize * option.height as usize * 4],
-                            (0, 0),
-                        ),
-                    ));
-                }
-            };
-            let slice = Slice::from(i_w_eff..i_w_eff + width_eff);
-            let im_slice = image.slice_axis(Axis(1), slice);
-
-            let pad_left = (-i_w.min(0)) as usize;
-            let pad_right = width as usize - width_eff as usize - pad_left;
-            if pad_left + pad_right == 0 {
-                Some((*tup, (im_slice.to_owned().into_raw_vec(), (0, width))))
-            } else {
-                let arr = utils::pad(
-                    im_slice,
-                    (pad_left, pad_right),
-                    Axis(1),
-                    utils::PadMode::Constant(0),
-                );
-                Some((
-                    *tup,
-                    (arr.into_raw_vec(), (pad_left as u32, width_eff as u32)),
-                ))
-            }
-        })
-        .collect();
-    eff_l_w_map.extend(
-        vec.iter()
-            .map(|(k, (_, eff_left_width))| (*k, *eff_left_width)),
-    );
-    imgs.extend(vec.into_iter().map(|(k, (img, _))| (k, img)));
-    // println!("crop: {:?}", start.elapsed());
-    (imgs, eff_l_w_map)
-}
-
-fn _categorize_id_ch(
-    id_ch_tuples: IdChVec,
-    total_widths: &IdChMap<u32>,
-    spec_caches: &GuardImgCaches,
-    wav_caches: &GuardImgCaches,
-    option: &DrawOption,
-    blend: f64,
-) -> (CategorizedIdChVec, CategorizedIdChVec, IdChVec) {
-    let categorize = |images: &GuardImgCaches| {
-        if option.height <= display::MAX_SIZE {
-            let mut result = CategorizedIdChVec::default();
-            for tup in id_ch_tuples.iter() {
-                let not_long_w = *total_widths.get(tup).unwrap() <= display::MAX_SIZE;
-                match (images.contains_key(tup), not_long_w) {
-                    (true, _) => result.use_caches.push(*tup),
-                    (false, true) => {
-                        result.need_parts.push(*tup);
-                        result.need_new_caches.push(*tup);
-                    }
-                    (false, false) => {
-                        result.need_parts.push(*tup);
-                    }
-                }
-            }
-            result
-        } else {
-            CategorizedIdChVec {
-                use_caches: Vec::new(),
-                need_parts: id_ch_tuples.to_owned(),
-                need_new_caches: Vec::new(),
-            }
-        }
-    };
-    let cat_by_spec = if blend > 0. {
-        categorize(spec_caches)
-    } else {
-        CategorizedIdChVec::default()
-    };
-    let mut cat_by_wav = if blend < 1. {
-        categorize(wav_caches)
-    } else {
-        CategorizedIdChVec::default()
-    };
-    let mut need_wav_parts_only = Vec::new();
-    {
-        let (mut i, mut j) = (0, 0);
-        while i < cat_by_spec.use_caches.len() && j < cat_by_wav.use_caches.len() {
-            if cat_by_spec.use_caches[i] == cat_by_wav.use_caches[j] {
-                i += 1;
-                j += 1;
-            } else {
-                need_wav_parts_only.push(cat_by_spec.use_caches[i]);
-                i += 1;
-                let index = cat_by_wav
-                    .need_parts
-                    .iter()
-                    .position(|x| *x == cat_by_spec.use_caches[i])
-                    .unwrap();
-                cat_by_wav.need_parts.remove(index);
-            }
-        }
-    }
-    assert!(
-        cat_by_spec.need_parts.len() == 0
-            || cat_by_wav.need_parts.len() == 0
-            || cat_by_spec.need_parts.len() == cat_by_wav.need_parts.len()
-    );
-    (cat_by_spec, cat_by_wav, need_wav_parts_only)
-}
-
-async fn _draw_imgs(
-    id_ch_tuples: IdChVec,
-    params: Arc<RwLock<DrawParams>>,
-    spec_caches: ArcImgCaches,
-    wav_caches: ArcImgCaches,
-    img_tx: Sender<Images>,
-) {
-    let params_backup = params.read().unwrap().clone();
-    let DrawParams {
-        sec,
-        width,
-        option,
-        opt_for_wav,
-        blend,
-    } = params_backup;
-    let blend_images = |spec_imgs: Images, wav_imgs: Images, eff_l_w_map: IdChMap<(u32, u32)>| {
-        if blend == 1. {
-            spec_imgs
-        } else if blend == 0. {
-            wav_imgs
-        } else {
-            spec_imgs
-                .par_iter()
-                .filter_map(|(k, spec_img)| {
-                    let wav_img = wav_imgs.get(k)?;
-                    let eff_l_w = eff_l_w_map.get(k).cloned().unwrap_or((0, 0));
-                    let img =
-                        display::blend(spec_img, wav_img, width, option.height, blend, eff_l_w);
-                    Some((*k, img))
-                })
-                .collect()
-        }
-    };
-    let (total_widths, cat_by_spec, cat_by_wav, blended_imgs) = {
-        let tm = TM.read().unwrap();
-        let id_ch_tuples: IdChVec = id_ch_tuples.into_iter().filter(|x| tm.exists(x)).collect();
-        let mut total_widths = IdChMap::<u32>::with_capacity(id_ch_tuples.len());
-        total_widths.extend(id_ch_tuples.iter().map(|&(id, ch)| {
-            let width = tm.tracks.get(&id).unwrap().calc_width(option.px_per_sec);
-            ((id, ch), width)
-        }));
-
-        let spec_caches_lock = spec_caches.lock().unwrap();
-        let wav_caches_lock = wav_caches.lock().unwrap();
-        let (cat_by_spec, cat_by_wav, need_wav_parts_only) = _categorize_id_ch(
-            id_ch_tuples,
-            &total_widths,
-            &spec_caches_lock,
-            &wav_caches_lock,
-            &option,
-            blend,
-        );
-
-        // crop image cache
-        let (spec_imgs, eff_l_w_map) = if !cat_by_spec.use_caches.is_empty() {
-            _crop_caches(
-                &spec_caches_lock,
-                &cat_by_spec.use_caches[..],
-                sec,
-                width,
-                &option,
-            )
-        } else {
-            (Images::new(), IdChMap::new())
-        };
-        let mut wav_imgs = if !cat_by_wav.use_caches.is_empty() {
-            _crop_caches(
-                &wav_caches_lock,
-                &cat_by_wav.use_caches[..],
-                sec,
-                width,
-                &option,
-            )
-            .0
-        } else {
-            Images::new()
-        };
-        if !need_wav_parts_only.is_empty() {
-            wav_imgs.extend(tm.get_part_images(
-                &need_wav_parts_only[..],
-                sec,
-                width,
-                option,
-                ImageKind::Wav(opt_for_wav),
-                None,
-            ));
-        };
-        (
-            total_widths,
-            cat_by_spec,
-            cat_by_wav,
-            blend_images(spec_imgs, wav_imgs, eff_l_w_map),
-        )
-    };
-    if !blended_imgs.is_empty() {
-        // println!("send cached images");
-        img_tx.send(blended_imgs).await.unwrap();
-    }
-    if *params.read().unwrap() != params_backup {
-        return;
-    }
-
-    // draw part
-    let blended_imgs = {
-        let tm = TM.read().unwrap();
-        if !cat_by_spec.need_parts.is_empty() {
-            let fast_resize_vec = if option.height <= display::MAX_SIZE {
-                Some(
-                    cat_by_spec
-                        .need_parts
-                        .iter()
-                        .map(|tup| *total_widths.get(tup).unwrap() <= display::MAX_SIZE)
-                        .collect(),
-                )
-            } else {
-                None
-            };
-            tm.get_blended_part_images(
-                &cat_by_spec.need_parts[..],
-                sec,
-                width,
-                option,
-                opt_for_wav,
-                blend,
-                fast_resize_vec,
-            )
-        } else {
-            IdChMap::new()
-        }
-    };
-    if !blended_imgs.is_empty() {
-        // println!("send part images");
-        img_tx.send(blended_imgs).await.unwrap();
-    }
-    if *params.read().unwrap() != params_backup {
-        return;
-    }
-
-    let blended_imgs = {
-        let tm = TM.read().unwrap();
-        let mut spec_caches_lock = spec_caches.lock().unwrap();
-        let mut wav_caches_lock = wav_caches.lock().unwrap();
-        let (spec_imgs, eff_l_w_map) = if !cat_by_spec.need_new_caches.is_empty() {
-            spec_caches_lock.extend(tm.get_entire_images(
-                &cat_by_spec.need_new_caches[..],
-                option,
-                ImageKind::Spec,
-            ));
-            _crop_caches(
-                &spec_caches_lock,
-                &cat_by_spec.need_new_caches[..],
-                sec,
-                width,
-                &option,
-            )
-        } else {
-            (Images::new(), IdChMap::new())
-        };
-        let wav_imgs = if !cat_by_wav.need_new_caches.is_empty() {
-            wav_caches_lock.extend(tm.get_entire_images(
-                &cat_by_wav.need_new_caches[..],
-                option,
-                ImageKind::Wav(opt_for_wav),
-            ));
-            _crop_caches(
-                &wav_caches_lock,
-                &cat_by_wav.need_new_caches[..],
-                sec,
-                width,
-                &option,
-            )
-            .0
-        } else {
-            IdChMap::new()
-        };
-        blend_images(spec_imgs, wav_imgs, eff_l_w_map)
-    };
-    if !blended_imgs.is_empty() {
-        // println!("send new cached images");
-        img_tx.send(blended_imgs).await.unwrap();
-    }
-}
-
-async fn _manage_imgs(mut rx: Receiver<ImgMsg>, img_tx: Sender<Images>) {
-    let spec_caches = Arc::new(Mutex::new(IdChMap::new()));
-    let wav_caches = Arc::new(Mutex::new(IdChMap::new()));
-    let prev_params = Arc::new(RwLock::new(DrawParams::default()));
-    let mut task_handle: Option<JoinHandle<()>> = None;
-    while let Some(msg) = rx.recv().await {
-        match msg {
-            ImgMsg::Draw((id_ch_tuples, draw_params)) => {
-                {
-                    let mut prev_params_write = prev_params.write().unwrap();
-                    if let Some(prev_task) = task_handle.take() {
-                        prev_task.abort();
-                    }
-                    // if draw_params != *prev_params_write {
-                    //     let waker = task::noop_waker();
-                    //     let mut cx = Context::from_waker(&waker);
-                    //     let img_rx = unsafe { IMG_RX.as_mut().unwrap() };
-                    //     while let Poll::Ready(Some(_)) = img_rx.poll_recv(&mut cx) {}
-                    // }
-                    if draw_params.option != prev_params_write.option {
-                        spec_caches.lock().unwrap().clear();
-                        wav_caches.lock().unwrap().clear();
-                    } else if draw_params.opt_for_wav != prev_params_write.opt_for_wav {
-                        wav_caches.lock().unwrap().clear();
-                    }
-                    *prev_params_write = draw_params;
-                }
-                task_handle = Some(RUNTIME.spawn(_draw_imgs(
-                    id_ch_tuples,
-                    Arc::clone(&prev_params),
-                    Arc::clone(&spec_caches),
-                    Arc::clone(&wav_caches),
-                    img_tx.clone(),
-                )));
-            }
-            ImgMsg::Remove(id_ch_tuples) => {
-                if let Some(prev_task) = task_handle.take() {
-                    prev_task.await.ok();
-                }
-                let mut spec_caches = spec_caches.lock().unwrap();
-                let mut wav_caches = wav_caches.lock().unwrap();
-                for tup in id_ch_tuples.iter() {
-                    spec_caches.remove(tup);
-                    wav_caches.remove(tup);
-                }
-            }
-        }
-    }
-}
-
 #[module_exports]
 fn init(mut exports: JsObject) -> JsResult<()> {
     initialize(&TM);
-    initialize(&RUNTIME);
-
-    let (img_mngr_tx, img_mngr_rx) = mpsc::channel::<ImgMsg>(60);
-    let (img_tx, img_rx) = mpsc::channel(60);
-    unsafe {
-        IMG_MNGR_TX = Some(img_mngr_tx);
-        IMG_RX = Some(img_rx);
-    }
-    RUNTIME.spawn(_manage_imgs(img_mngr_rx, img_tx));
+    img_mgr::spawn_runtime();
 
     exports.create_named_method("addTracks", add_tracks)?;
     exports.create_named_method("reloadTracks", reload_tracks)?;

--- a/src/App.js
+++ b/src/App.js
@@ -22,13 +22,13 @@ function App() {
 
   const [trackIds, setTrackIds] = useState([]);
   const [erroredList, setErroredList] = useState([]);
-  const [refreshList, setRefreshList] = useState(null);
+  const [refreshList, setRefreshList] = useState([]);
 
   async function reloadTracks(selectedIds) {
     const reloadedIds = native.reloadTracks(selectedIds);
 
     setErroredList(selectedIds.filter((id) => !reloadedIds.includes(id)));
-    setRefreshList(await native.applyTrackListChanges());
+    setRefreshList(native.applyTrackListChanges());
   }
   async function addTracks(newPaths, unsupportedPaths) {
     try {
@@ -102,7 +102,7 @@ function App() {
       if (existingIds.length) {
         reloadTracks(existingIds);
       } else {
-        setRefreshList(await native.applyTrackListChanges());
+        setRefreshList(native.applyTrackListChanges());
       }
     } catch (err) {
       console.log(err);
@@ -119,10 +119,7 @@ function App() {
       setTrackIds((trackIds) => trackIds.filter((id) => !selectedIds.includes(id)));
       setErroredList(erroredList.filter((id) => !selectedIds.includes(id)));
 
-      const promiseRefreshList = native.applyTrackListChanges();
-      if (promiseRefreshList) {
-        setRefreshList(await promiseRefreshList);
-      }
+      setRefreshList(native.applyTrackListChanges());
 
       waitingIdsRef.current = waitingIdsRef.current.concat(selectedIds);
       if (waitingIdsRef.current.length > 1) {

--- a/src/components/MainViewer/Canvas.js
+++ b/src/components/MainViewer/Canvas.js
@@ -2,51 +2,16 @@ import React, {forwardRef, useRef, useImperativeHandle} from "react";
 
 const Canvas = forwardRef(({width, height}, ref) => {
   const canvasElem = useRef(null);
-  const timeRef = useRef(0);
 
   useImperativeHandle(ref, () => ({
-    draw: (bufs) => {
-      const [bufSpec, bufWav] = bufs;
-      if (!bufSpec && !bufWav) {
+    draw: async (buf) => {
+      if (!(buf && buf.byteLength === 4 * width * height)) {
         return;
       }
-      if (
-        !(bufSpec && bufSpec.byteLength === 4 * width * height) &&
-        !(bufWav && bufWav.byteLength === 4 * width * height)
-      ) {
-        return;
-      }
-      // console.log(canvas.current);
-      // const ctx = canvas.current.getContext("bitmaprenderer");
-      // const imdata = new ImageData(new Uint8ClampedArray(bufSpec), width, height);
-      // const imbmp = await createImageBitmap(imdata);
-      // ctx.transferFromImageBitmap(imbmp);
-
-      requestAnimationFrame(async (timestamp) => {
-        if (timeRef.current === timestamp) return;
-        timeRef.current = timestamp;
-        const imgSpec = new ImageData(new Uint8ClampedArray(bufSpec), width, height);
-        const imgWav = new ImageData(new Uint8ClampedArray(bufWav), width, height);
-        const offscreen = new OffscreenCanvas(width, height);
-        const ctx = offscreen.getContext("2d");
-        ctx.clearRect(0, 0, width, height);
-        const promiseBmpSpec = createImageBitmap(imgSpec);
-        const promiseBmpWav = createImageBitmap(imgWav);
-        const [bmpSpec, bmpWav] = await Promise.all([promiseBmpSpec, promiseBmpWav]);
-        ctx.drawImage(bmpSpec, 0, 0);
-        ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
-        ctx.fillRect(0, 0, offscreen.width, offscreen.height);
-        ctx.drawImage(bmpWav, 0, 0);
-        canvasElem.current
-          .getContext("bitmaprenderer")
-          .transferFromImageBitmap(offscreen.transferToImageBitmap());
-        // imgWav.data.forEach((d, i, a) => {
-        //   if ((i + 1) % 4) {
-        //     a[i] = 128;
-        //   }
-        // });
-        // ctx.putImageData(imgWav, 0, 0);
-      });
+      const ctx = canvasElem.current.getContext("bitmaprenderer");
+      const imdata = new ImageData(new Uint8ClampedArray(buf), width, height);
+      const imbmp = await createImageBitmap(imdata);
+      ctx.transferFromImageBitmap(imbmp);
     },
   }));
 

--- a/src/components/MainViewer/MainViewer.js
+++ b/src/components/MainViewer/MainViewer.js
@@ -245,7 +245,6 @@ function MainViewer({
     const secOutOfCanvas = maxTrackSecRef.current - width / drawOptionRef.current.px_per_sec;
     if (canvasIsFitRef.current) {
       drawOptionRef.current.px_per_sec = width / maxTrackSecRef.current;
-      throttledSetImgState(getIdChArr(), width, height);
     } else {
       if (secOutOfCanvas <= 0) {
         canvasIsFitRef.current = true;
@@ -254,8 +253,8 @@ function MainViewer({
       if (secRef.current > secOutOfCanvas) {
         secRef.current = secOutOfCanvas;
       }
-      throttledSetImgState(getIdChArr(), width, height);
     }
+    throttledSetImgState(getIdChArr(), width, height);
   }, [width]);
 
   useEffect(() => {

--- a/src/components/MainViewer/MainViewer.js
+++ b/src/components/MainViewer/MainViewer.js
@@ -1,5 +1,5 @@
 import React, {useRef, useCallback, useEffect, useState} from "react";
-import {throttle, debounce} from "throttle-debounce";
+import {throttle} from "throttle-debounce";
 
 import "./MainViewer.scss";
 import {SplitView} from "./SplitView";

--- a/src/components/MainViewer/MainViewer.js
+++ b/src/components/MainViewer/MainViewer.js
@@ -103,7 +103,7 @@ function MainViewer({
         if (drawOptionRef.current.px_per_sec !== pxPerSec) {
           drawOptionRef.current.px_per_sec = pxPerSec;
           canvasIsFitRef.current = false;
-          throttledSetImgState(getIdChArr());
+          throttledSetImgState(getIdChArr(), width, height);
         }
       } else {
         setHeight(Math.round(Math.min(Math.max(height * (1 + e.deltaY / 1000), 10), 5000)));
@@ -117,13 +117,13 @@ function MainViewer({
       );
       if (secRef.current !== tempSec) {
         secRef.current = tempSec;
-        throttledSetImgState(getIdChArr());
+        throttledSetImgState(getIdChArr(), width, height);
       }
     }
   };
 
   const throttledSetImgState = useCallback(
-    throttle(1000 / 120, (idChArr) => {
+    throttle(1000 / 240, (idChArr, width, height) => {
       if (idChArr.length === 0) return;
       setImgState(
         idChArr,
@@ -134,7 +134,7 @@ function MainViewer({
         0.3,
       );
     }),
-    [height, width],
+    [],
   );
 
   const draw = (_) => {
@@ -150,7 +150,7 @@ function MainViewer({
     requestRef.current = requestAnimationFrame(draw);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     requestRef.current = requestAnimationFrame(draw);
     return () => cancelAnimationFrame(requestRef.current);
   }, []);
@@ -245,7 +245,7 @@ function MainViewer({
     const secOutOfCanvas = maxTrackSecRef.current - width / drawOptionRef.current.px_per_sec;
     if (canvasIsFitRef.current) {
       drawOptionRef.current.px_per_sec = width / maxTrackSecRef.current;
-      throttledSetImgState(getIdChArr());
+      throttledSetImgState(getIdChArr(), width, height);
     } else {
       if (secOutOfCanvas <= 0) {
         canvasIsFitRef.current = true;
@@ -254,13 +254,13 @@ function MainViewer({
       if (secRef.current > secOutOfCanvas) {
         secRef.current = secOutOfCanvas;
       }
-      throttledSetImgState(getIdChArr());
+      throttledSetImgState(getIdChArr(), width, height);
     }
   }, [width]);
 
   useEffect(() => {
     if (!trackIds.length) return;
-    throttledSetImgState(getIdChArr());
+    throttledSetImgState(getIdChArr(), width, height);
   }, [height]);
 
   useEffect(() => {
@@ -268,7 +268,7 @@ function MainViewer({
   }, [erroredList]);
 
   useEffect(() => {
-    throttledSetImgState(refreshList);
+    throttledSetImgState(refreshList, width, height);
     dropReset();
   }, [refreshList]);
 

--- a/src/components/MainViewer/MainViewer.js
+++ b/src/components/MainViewer/MainViewer.js
@@ -8,7 +8,8 @@ import Canvas from "./Canvas";
 import {PROPERTY} from "../Property";
 
 const {native} = window.preload;
-const {getFileName, getMaxSec, getNumCh, getSampleFormat, getSec, getSr, getSpecWavImages} = native;
+const {getFileName, getMaxSec, getNumCh, getSampleFormat, getSec, getSr, setImgState, getImages} =
+  native;
 const CHANNEL = PROPERTY.CHANNEL;
 
 function useRefs() {
@@ -47,6 +48,7 @@ function MainViewer({
   const [height, setHeight] = useState(250);
   const drawOptionRef = useRef({px_per_sec: 100});
   const [children, registerChild] = useRefs();
+  const requestRef = React.useRef();
 
   const dragOver = (e) => {
     e.preventDefault();
@@ -101,7 +103,7 @@ function MainViewer({
         if (drawOptionRef.current.px_per_sec !== pxPerSec) {
           drawOptionRef.current.px_per_sec = pxPerSec;
           canvasIsFitRef.current = false;
-          throttledDraw([getIdChArr()]);
+          throttledSetImgState(getIdChArr());
         }
       } else {
         setHeight(Math.round(Math.min(Math.max(height * (1 + e.deltaY / 1000), 10), 5000)));
@@ -115,46 +117,43 @@ function MainViewer({
       );
       if (secRef.current !== tempSec) {
         secRef.current = tempSec;
-        throttledDraw([getIdChArr()]);
+        throttledSetImgState(getIdChArr());
       }
     }
   };
 
-  const draw = useCallback(
-    async (idChArr) => {
-      if (idChArr.reduce((sum, x) => sum + x.length, 0) === 0) return;
-      const [images, promise] = getSpecWavImages(
-        idChArr[0],
+  const throttledSetImgState = useCallback(
+    throttle(1000 / 120, (idChArr) => {
+      if (idChArr.length === 0) return;
+      setImgState(
+        idChArr,
         secRef.current,
         width,
         {...drawOptionRef.current, height: height},
         {min_amp: -1, max_amp: 1},
+        0.3,
       );
-
-      for (const [idChStr, bufs] of Object.entries(images)) {
-        const ref = children.current[idChStr];
-        // let promises = [];
-        if (ref) {
-          // promises.push(
-          ref.draw(bufs);
-          // );
-        }
-        // Promise.all(promises);
-      }
-
-      // cached image
-      if (promise !== null) {
-        const arr = await promise;
-        debouncedDraw(arr);
-      }
-    },
+    }),
     [height, width],
   );
 
-  const throttledDraw = useCallback(throttle(1000 / 60, draw), [draw]);
-  const debouncedDraw = useCallback(debounce(1000 / 30, draw), [draw]);
-  // const throttledDraw = draw;
-  // const debouncedDraw = draw;
+  const draw = (_) => {
+    const images = getImages();
+    let promises = [];
+    for (const [idChStr, buf] of Object.entries(images)) {
+      const ref = children.current[idChStr];
+      if (ref) {
+        promises.push(ref.draw(buf));
+      }
+    }
+    Promise.all(promises);
+    requestRef.current = requestAnimationFrame(draw);
+  };
+
+  React.useEffect(() => {
+    requestRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(requestRef.current);
+  }, []);
 
   const dropbox = <div className="dropbox"></div>;
 
@@ -246,7 +245,7 @@ function MainViewer({
     const secOutOfCanvas = maxTrackSecRef.current - width / drawOptionRef.current.px_per_sec;
     if (canvasIsFitRef.current) {
       drawOptionRef.current.px_per_sec = width / maxTrackSecRef.current;
-      throttledDraw([getIdChArr()]);
+      throttledSetImgState(getIdChArr());
     } else {
       if (secOutOfCanvas <= 0) {
         canvasIsFitRef.current = true;
@@ -255,13 +254,13 @@ function MainViewer({
       if (secRef.current > secOutOfCanvas) {
         secRef.current = secOutOfCanvas;
       }
-      throttledDraw([getIdChArr()]);
+      throttledSetImgState(getIdChArr());
     }
   }, [width]);
 
   useEffect(() => {
     if (!trackIds.length) return;
-    debouncedDraw([getIdChArr()]);
+    throttledSetImgState(getIdChArr());
   }, [height]);
 
   useEffect(() => {
@@ -269,9 +268,7 @@ function MainViewer({
   }, [erroredList]);
 
   useEffect(() => {
-    if (refreshList) {
-      draw(refreshList);
-    }
+    throttledSetImgState(refreshList);
     dropReset();
   }, [refreshList]);
 

--- a/src/components/MainViewer/MainViewer.js
+++ b/src/components/MainViewer/MainViewer.js
@@ -48,7 +48,7 @@ function MainViewer({
   const [height, setHeight] = useState(250);
   const drawOptionRef = useRef({px_per_sec: 100});
   const [children, registerChild] = useRefs();
-  const requestRef = React.useRef();
+  const requestRef = useRef();
 
   const dragOver = (e) => {
     e.preventDefault();
@@ -149,11 +149,6 @@ function MainViewer({
     Promise.all(promises);
     requestRef.current = requestAnimationFrame(draw);
   };
-
-  useEffect(() => {
-    requestRef.current = requestAnimationFrame(draw);
-    return () => cancelAnimationFrame(requestRef.current);
-  }, []);
 
   const dropbox = <div className="dropbox"></div>;
 
@@ -285,6 +280,11 @@ function MainViewer({
     }
     prevTrackCountRef.current = trackIds.length;
   }, [trackIds]);
+
+  useEffect(() => {
+    requestRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(requestRef.current);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
### Rust backend
- "Tokio runtime" manages image drawing task and image caches asynchronously.
- Whenever receiving image state ( id & ch to draw, sec, width, height, ...) from frontend, it aborts existing drawing task, and starts new drawing task.
- A drawing task does
    1.  cropping existing caches and send them to channel
    2. If caches don't exist, drawing low-resolution version and send them to channel
    3. drawing high-resolution caches, cropping them, and send them to channel
- Whenever frontend requests images, the latest images in channel are returned.

### JS frontend
- It sends image state to backend without receiving images.
- It retrieves images from backend only at every "animation frame" (by using requestAnimationFrame),
so unnecessary canvas update doesn't happen.