### PR TITLE
feat: multiple selection of tracks

### DIFF
--- a/src/renderer/@types/track.d.ts
+++ b/src/renderer/@types/track.d.ts
@@ -3,6 +3,8 @@ type IdChannel = import("../api").IdChannel;
 type IdChArr = IdChannel[];
 type IdChMap = Map<number, IdChArr>;
 
+type MouseOrKeyboardEvent = MouseEvent | KeyboardEvent | React.MouseEvent | React.KeyboardEvent;
+
 type OptionalLensParams = {startSec?: number; pxPerSec?: number};
 
 type SplitViewHandleElement = {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -36,8 +36,13 @@ function MyApp() {
     setCommonGuardClipping,
     finishRefreshTracks,
   } = useTracks();
-  const {selectedTrackIds, selectTrack, selectTrackAfterAddTracks, selectTrackAfterRemoveTracks} =
-    useSelectedTracks();
+  const {
+    selectedTrackIds,
+    selectTrack,
+    selectAllTracks,
+    selectTrackAfterAddTracks,
+    selectTrackAfterRemoveTracks,
+  } = useSelectedTracks();
 
   const prevTrackIds = useRef<number[]>([]);
 
@@ -161,6 +166,7 @@ function MyApp() {
             reloadTracks={reloadTracks}
             removeTracks={removeTracks}
             selectTrack={selectTrack}
+            selectAllTracks={selectAllTracks}
             finishRefreshTracks={finishRefreshTracks}
           />
         </DevicePixelRatioProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -100,15 +100,18 @@ function MyApp() {
     };
   }, [addTracks, reloadTracks, refreshTracks]);
 
+  const removeSelectedTracks = useEvent(async (_, targetTrackId) => {
+    if (selectedTrackIds.includes(targetTrackId)) removeTracks(selectedTrackIds);
+    else removeTracks([targetTrackId]);
+    await refreshTracks();
+  });
+
   useEffect(() => {
-    ipcRenderer.on("delete-track", async (_, targetTrackId) => {
-      removeTracks([targetTrackId]);
-      await refreshTracks();
-    });
+    ipcRenderer.on("delete-track", removeSelectedTracks);
     return () => {
       ipcRenderer.removeAllListeners("delete-track");
     };
-  }, [removeTracks, refreshTracks]);
+  }, [removeSelectedTracks]);
 
   useEffect(() => {
     const prevTrackIdsCount = prevTrackIds.current.length;

--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -59,7 +59,7 @@ function useSelectedTracks() {
     ) {
       return;
     }
-    setPivotId(trackIds[-1]);
+    setPivotId(trackIds[trackIds.length - 1]);
     setSelectedTrackIds(trackIds);
   });
 

--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -39,8 +39,9 @@ function useSelectedTracks() {
       if (indexOfId > indexOfPivot) addingIds = trackIds.slice(indexOfPivot + 1, indexOfId + 1);
       else addingIds = trackIds.slice(indexOfId, indexOfPivot);
       // if newSelected has some of addingIds, remove them first
-      newSelected = newSelected.filter((selectedId) => !addingIds.includes(selectedId));
-      newSelected.push(...addingIds);
+      newSelected = newSelected
+        .filter((selectedId) => !addingIds.includes(selectedId))
+        .concat(addingIds);
       setSelectedTrackIds(newSelected);
       return;
     }

--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -52,6 +52,17 @@ function useSelectedTracks() {
     setSelectedTrackIds([id]);
   });
 
+  const selectAllTracks = useEvent((trackIds: number[]) => {
+    if (
+      trackIds.length === selectedTrackIds.length &&
+      trackIds.every((id) => selectedTrackIds.includes(id))
+    ) {
+      return;
+    }
+    setPivotId(trackIds[-1]);
+    setSelectedTrackIds(trackIds);
+  });
+
   const selectTrackAfterAddTracks = useEvent((prevTrackIds: number[], newTrackIds: number[]) => {
     const newSelected = newTrackIds.filter((id) => !prevTrackIds.includes(id));
     if (newSelected.length === 0) return;
@@ -96,6 +107,7 @@ function useSelectedTracks() {
   return {
     selectedTrackIds,
     selectTrack,
+    selectAllTracks,
     selectTrackAfterAddTracks,
     selectTrackAfterRemoveTracks,
   };

--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -10,8 +10,8 @@ function useSelectedTracks() {
     e.preventDefault();
 
     if (isCommand(e)) {
-      const selectedIndexOfId = selectedTrackIds.indexOf(id);
-      if (selectedIndexOfId === -1) {
+      const idxInSelectedIds = selectedTrackIds.indexOf(id);
+      if (idxInSelectedIds === -1) {
         // add id
         setPivotId(id);
         setSelectedTrackIds(selectedTrackIds.concat([id]));
@@ -20,8 +20,8 @@ function useSelectedTracks() {
       if (selectedTrackIds.length === 1) return;
       // remove id
       const newSelected = selectedTrackIds
-        .slice(0, selectedIndexOfId)
-        .concat(selectedTrackIds.slice(selectedIndexOfId + 1, undefined));
+        .slice(0, idxInSelectedIds)
+        .concat(selectedTrackIds.slice(idxInSelectedIds + 1, undefined));
       if (pivotId === id) setPivotId(newSelected[newSelected.length - 1]);
       setSelectedTrackIds(newSelected);
       return;

--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -1,35 +1,81 @@
-import React, {useState} from "react";
+import {useState} from "react";
 import useEvent from "react-use-event-hook";
+import {isCommand} from "renderer/utils/commandKey";
 
 function useSelectedTracks() {
   const [selectedTrackIds, setSelectedTrackIds] = useState<number[]>([]);
+  const [pivotId, setPivotId] = useState<number>(0);
 
-  const selectTrack = useEvent((e: Event | React.MouseEvent, id: number) => {
+  const selectTrack = useEvent((e: MouseOrKeyboardEvent, id: number, trackIds: number[]) => {
     e.preventDefault();
 
+    if (isCommand(e)) {
+      const selectedIndexOfId = selectedTrackIds.indexOf(id);
+      if (selectedIndexOfId === -1) {
+        // add id
+        setPivotId(id);
+        setSelectedTrackIds(selectedTrackIds.concat([id]));
+        return;
+      }
+      if (selectedTrackIds.length === 1) return;
+      // remove id
+      const newSelected = selectedTrackIds
+        .slice(0, selectedIndexOfId)
+        .concat(selectedTrackIds.slice(selectedIndexOfId + 1, undefined));
+      if (pivotId === id) setPivotId(newSelected[newSelected.length - 1]);
+      setSelectedTrackIds(newSelected);
+      return;
+    }
+    if (e.shiftKey) {
+      if (id === selectedTrackIds[selectedTrackIds.length - 1]) return;
+      // const indexOfRecent = trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]);
+      const indexOfId = trackIds.indexOf(id);
+      const indexOfPivot = trackIds.indexOf(pivotId);
+      // remove ids that added after the pivot (by shift+select)
+      let newSelected = selectedTrackIds.slice(0, selectedTrackIds.indexOf(pivotId) + 1);
+
+      // add "one after pivot" ~ id
+      let addingIds: number[];
+      if (indexOfId > indexOfPivot) addingIds = trackIds.slice(indexOfPivot + 1, indexOfId + 1);
+      else addingIds = trackIds.slice(indexOfId, indexOfPivot);
+      // if newSelected has some of addingIds, remove them first
+      newSelected = newSelected.filter((selectedId) => !addingIds.includes(selectedId));
+      newSelected.push(...addingIds);
+      setSelectedTrackIds(newSelected);
+      return;
+    }
     // with nothing pressed
-    setSelectedTrackIds((current) => (id !== current[0] ? [id] : current));
+    if (selectedTrackIds.length === 1 && selectedTrackIds[0] === id) {
+      return;
+    }
+    setPivotId(id);
+    setSelectedTrackIds([id]);
   });
 
   const selectTrackAfterAddTracks = useEvent((prevTrackIds: number[], newTrackIds: number[]) => {
     const nextSelectedTrackIndex = prevTrackIds.length;
     if (newTrackIds.length > nextSelectedTrackIndex) {
       const nextSelectedTrackId = newTrackIds[nextSelectedTrackIndex];
+      setPivotId(nextSelectedTrackId);
       setSelectedTrackIds([nextSelectedTrackId]);
     }
   });
 
   const selectTrackAfterRemoveTracks = useEvent((prevTrackIds: number[], newTrackIds: number[]) => {
-    if (newTrackIds.length) {
-      let nextSelectedTrackIndex = newTrackIds.length - 1;
-      selectedTrackIds.forEach((id) => {
-        nextSelectedTrackIndex = Math.min(nextSelectedTrackIndex, prevTrackIds.indexOf(id));
-      });
-      const nextSelectedTrackId = newTrackIds[nextSelectedTrackIndex];
-
-      if (nextSelectedTrackId !== selectedTrackIds[0]) setSelectedTrackIds([nextSelectedTrackId]);
-    } else {
+    if (newTrackIds.length === 0) {
+      setPivotId(-1);
       setSelectedTrackIds([]);
+      return;
+    }
+    let nextSelectedTrackIndex = newTrackIds.length - 1;
+    selectedTrackIds.forEach((id) => {
+      nextSelectedTrackIndex = Math.min(nextSelectedTrackIndex, prevTrackIds.indexOf(id));
+    });
+    const nextSelectedTrackId = newTrackIds[nextSelectedTrackIndex];
+
+    if (nextSelectedTrackId !== selectedTrackIds[0]) {
+      setPivotId(nextSelectedTrackId);
+      setSelectedTrackIds([nextSelectedTrackId]);
     }
   });
 

--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -37,7 +37,7 @@ function useSelectedTracks() {
       // add "one after pivot" ~ id
       let addingIds: number[];
       if (indexOfId > indexOfPivot) addingIds = trackIds.slice(indexOfPivot + 1, indexOfId + 1);
-      else addingIds = trackIds.slice(indexOfId, indexOfPivot);
+      else addingIds = trackIds.slice(indexOfId, indexOfPivot).reverse();
       // if newSelected has some of addingIds, remove them first
       newSelected = newSelected
         .filter((selectedId) => !addingIds.includes(selectedId))

--- a/src/renderer/prototypes/MainViewer/MainViewer.tsx
+++ b/src/renderer/prototypes/MainViewer/MainViewer.tsx
@@ -415,7 +415,12 @@ function MainViewer(props: MainViewerProps) {
           break;
         case "ArrowUp":
           e.preventDefault();
-          selectTrack(e, trackIds[Math.max(trackIds.indexOf(selectedTrackIds[0]) - 1, 0)]);
+          selectTrack(
+            e,
+            trackIds[
+              Math.max(trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) - 1, 0)
+            ],
+          );
           break;
         case "ArrowRight":
           e.preventDefault();

--- a/src/renderer/prototypes/MainViewer/MainViewer.tsx
+++ b/src/renderer/prototypes/MainViewer/MainViewer.tsx
@@ -409,31 +409,20 @@ function MainViewer(props: MainViewerProps) {
         e.preventDefault();
         await deleteSelectedTracks(e);
         break;
-      case "ArrowDown":
+      case "ArrowDown": {
         e.preventDefault();
-        // this can't handle cmd+arrow
-        selectTrack(
-          e,
-          trackIds[
-            Math.min(
-              trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) + 1,
-              trackIds.length - 1,
-            )
-          ],
-          trackIds,
-        );
+        const recentSelectedIdx = trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]);
+        const nextTrackId = trackIds[Math.min(recentSelectedIdx + 1, trackIds.length - 1)];
+        selectTrack(e, nextTrackId, trackIds); // this can't handle cmd+arrow
         break;
-      case "ArrowUp":
+      }
+      case "ArrowUp": {
         e.preventDefault();
-        // this can't handle cmd+arrow
-        selectTrack(
-          e,
-          trackIds[
-            Math.max(trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) - 1, 0)
-          ],
-          trackIds,
-        );
+        const recentSelectedIdx = trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]);
+        const prevTrackId = trackIds[Math.max(recentSelectedIdx - 1, 0)];
+        selectTrack(e, prevTrackId, trackIds); // this can't handle cmd+arrow
         break;
+      }
       case "ArrowRight":
         e.preventDefault();
         updateLensParams({startSec: startSecRef.current + 10 / pxPerSecRef.current});

--- a/src/renderer/prototypes/MainViewer/MainViewer.tsx
+++ b/src/renderer/prototypes/MainViewer/MainViewer.tsx
@@ -57,7 +57,7 @@ type MainViewerProps = {
   refreshTracks: () => Promise<void>;
   ignoreError: (id: number) => void;
   removeTracks: (ids: number[]) => void;
-  selectTrack: (e: Event | React.MouseEvent, id: number) => void;
+  selectTrack: (e: MouseOrKeyboardEvent, id: number, trackIds: number[]) => void;
   finishRefreshTracks: () => void;
 };
 
@@ -394,45 +394,50 @@ function MainViewer(props: MainViewerProps) {
         default:
           break;
       }
-    } else {
-      switch (e.key) {
-        case "Delete":
-        case "Backspace":
-          e.preventDefault();
-          await deleteSelectedTracks(e);
-          break;
-        case "ArrowDown":
-          e.preventDefault();
-          selectTrack(
-            e,
-            trackIds[
-              Math.min(
-                trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) + 1,
-                trackIds.length - 1,
-              )
-            ],
-          );
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          selectTrack(
-            e,
-            trackIds[
-              Math.max(trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) - 1, 0)
-            ],
-          );
-          break;
-        case "ArrowRight":
-          e.preventDefault();
-          updateLensParams({startSec: startSecRef.current + 10 / pxPerSecRef.current});
-          break;
-        case "ArrowLeft":
-          e.preventDefault();
-          updateLensParams({startSec: startSecRef.current - 10 / pxPerSecRef.current});
-          break;
-        default:
-          break;
-      }
+      return;
+    }
+    // no modifiers
+    switch (e.key) {
+      case "Delete":
+      case "Backspace":
+        e.preventDefault();
+        await deleteSelectedTracks(e);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        // this can't handle cmd+arrow
+        selectTrack(
+          e,
+          trackIds[
+            Math.min(
+              trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) + 1,
+              trackIds.length - 1,
+            )
+          ],
+          trackIds,
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        // this can't handle cmd+arrow
+        selectTrack(
+          e,
+          trackIds[
+            Math.max(trackIds.indexOf(selectedTrackIds[selectedTrackIds.length - 1]) - 1, 0)
+          ],
+          trackIds,
+        );
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        updateLensParams({startSec: startSecRef.current + 10 / pxPerSecRef.current});
+        break;
+      case "ArrowLeft":
+        e.preventDefault();
+        updateLensParams({startSec: startSecRef.current - 10 / pxPerSecRef.current});
+        break;
+      default:
+        break;
     }
   });
 
@@ -488,7 +493,7 @@ function MainViewer(props: MainViewerProps) {
             channelHeight={height}
             imgHeight={imgHeight}
             isSelected={isSelected}
-            selectTrack={selectTrack}
+            onClick={(e) => selectTrack(e, trackId, trackIds)}
           />
         );
       })}
@@ -529,7 +534,7 @@ function MainViewer(props: MainViewerProps) {
                 className={styles.chCanvases}
                 role="presentation"
                 onClick={(e) => {
-                  selectTrack(e, id);
+                  selectTrack(e, id, trackIds);
                 }}
               >
                 <ImgCanvas

--- a/src/renderer/prototypes/MainViewer/MainViewer.tsx
+++ b/src/renderer/prototypes/MainViewer/MainViewer.tsx
@@ -58,6 +58,7 @@ type MainViewerProps = {
   ignoreError: (id: number) => void;
   removeTracks: (ids: number[]) => void;
   selectTrack: (e: MouseOrKeyboardEvent, id: number, trackIds: number[]) => void;
+  selectAllTracks: (trackIds: number[]) => void;
   finishRefreshTracks: () => void;
 };
 
@@ -76,6 +77,7 @@ function MainViewer(props: MainViewerProps) {
     reloadTracks,
     removeTracks,
     selectTrack,
+    selectAllTracks,
     finishRefreshTracks,
   } = props;
 
@@ -390,6 +392,10 @@ function MainViewer(props: MainViewerProps) {
         case "ArrowLeft":
           e.preventDefault();
           updateLensParams({pxPerSec: pxPerSecRef.current - calcPxPerSecDelta()});
+          break;
+        case "a":
+          e.preventDefault();
+          selectAllTracks(trackIds);
           break;
         default:
           break;

--- a/src/renderer/prototypes/MainViewer/TrackInfo.module.scss
+++ b/src/renderer/prototypes/MainViewer/TrackInfo.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex: 0 0 auto;
   position: relative;
+  user-select: none;
 }
 
 // track summary

--- a/src/renderer/prototypes/MainViewer/TrackInfo.tsx
+++ b/src/renderer/prototypes/MainViewer/TrackInfo.tsx
@@ -52,7 +52,7 @@ const TrackInfo = forwardRef((props: TrackInfoProps, ref) => {
       role="presentation"
       className={`${styles.TrackInfo} ${isSelected ? styles.selected : ""}`}
       onClick={onClick}
-      onContextMenu={(e) => showTrackContextMenu(e, trackId)} // TODO: need optimization?
+      onContextMenu={(e) => showTrackContextMenu(e, trackId)} // TODO: if (!isSelected), show highlight instead
       style={{
         margin: `${VERTICAL_AXIS_PADDING}px 0`,
         height: channelHeight * trackIdCh.length - 2 * VERTICAL_AXIS_PADDING,

--- a/src/renderer/prototypes/MainViewer/TrackInfo.tsx
+++ b/src/renderer/prototypes/MainViewer/TrackInfo.tsx
@@ -13,7 +13,7 @@ type TrackInfoProps = {
   channelHeight: number;
   imgHeight: number;
   isSelected: boolean;
-  selectTrack: (e: Event | React.MouseEvent, id: number) => void;
+  onClick: (e: React.MouseEvent) => void;
 };
 
 const showTrackContextMenu = (e: React.MouseEvent, trackId: number) => {
@@ -29,7 +29,7 @@ const TrackInfo = forwardRef((props: TrackInfoProps, ref) => {
     channelHeight,
     imgHeight,
     isSelected,
-    selectTrack,
+    onClick,
   } = props;
   const trackInfoElem = useRef<HTMLDivElement>(null);
 
@@ -51,7 +51,7 @@ const TrackInfo = forwardRef((props: TrackInfoProps, ref) => {
       ref={trackInfoElem}
       role="presentation"
       className={`${styles.TrackInfo} ${isSelected ? styles.selected : ""}`}
-      onClick={(e) => selectTrack(e, trackId)} // TODO: need optimization?
+      onClick={onClick}
       onContextMenu={(e) => showTrackContextMenu(e, trackId)} // TODO: need optimization?
       style={{
         margin: `${VERTICAL_AXIS_PADDING}px 0`,

--- a/src/renderer/utils/commandKey.ts
+++ b/src/renderer/utils/commandKey.ts
@@ -1,11 +1,9 @@
-import React from "react";
-
 function isApple() {
   const expression = /(Mac|iPhone|iPod|iPad)/i;
   return expression.test(navigator.platform);
 }
 
-export function isCommand(event: KeyboardEvent | React.KeyboardEvent) {
+export function isCommand(event: MouseOrKeyboardEvent) {
   // Returns true if Ctrl or cmd keys were pressed.
   if (isApple()) {
     return event.metaKey;
@@ -13,7 +11,7 @@ export function isCommand(event: KeyboardEvent | React.KeyboardEvent) {
   return event.ctrlKey; // Windows, Linux, UNIX
 }
 
-export function isCommandOnly(event: KeyboardEvent | React.KeyboardEvent) {
+export function isCommandOnly(event: MouseOrKeyboardEvent) {
   // Returns true if Ctrl or cmd keys were pressed.
   if (isApple()) {
     return event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;


### PR DESCRIPTION
This implements multiple selection by cmd+click, shift+click, shift+arrowup/down

### Multiple selection behaviours

The behaviour is close to that of macOS Finder. (not exactly the same)
**pivot** is needed for shift+click.

1. click
   - the clicked one is the only selection
   - it becomes the pivot
3. cmd+click
   - if the clicked one is *not* already selected
       - add the clicked one to the selection
       - it becomes the pivot
   - otherwise
       - remove the clicked on from the selection
       -  if it was the pivot, the recently selected one becomes the pivot
4. shift+click / shift+arrowup/down
   - the pivot is not changed.
   - first, **remove** all tracks *selected after the pivot*
   - then, add all tracks between the pivot and the clicked one (including the clicked one).
      - For shift+arrowup/down, the clicked one means a track before/after the recently selected one, respectively.

### Changes of behaviour of adding/removing  tracks
1. after adding
   - select *all the added tracks*
2. "delete track" context menu
   - if the menu is popped up on one of the selections, remove *all the selections*
   - otherwise, remove that track only. (**TODO**: we have to indicate this behaviour for users)
3. after removing
   - retain not-removed selection.
   - if no retain exists, the nearest track from the previous track is selected