### PR TITLE
[feat] trackpad pinch to zoom img

### DIFF
--- a/src/renderer/hooks/useSelectedTracks.ts
+++ b/src/renderer/hooks/useSelectedTracks.ts
@@ -1,6 +1,6 @@
 import {useState} from "react";
 import useEvent from "react-use-event-hook";
-import {isCommand} from "renderer/utils/commandKey";
+import {isCommand} from "renderer/utils/osSpecifics";
 
 function useSelectedTracks() {
   const [selectedTrackIds, setSelectedTrackIds] = useState<number[]>([]);

--- a/src/renderer/prototypes/MainViewer/MainViewer.tsx
+++ b/src/renderer/prototypes/MainViewer/MainViewer.tsx
@@ -309,17 +309,21 @@ function MainViewer(props: MainViewerProps) {
   const handleWheel = useEvent((e: WheelEvent) => {
     if (!trackIds.length) return;
 
-    let delta: number;
     let horizontal: boolean;
-    if (Math.abs(e.deltaY) < Math.abs(e.deltaX)) {
-      delta = e.deltaX;
+    let delta: number;
+    if (e.ctrlKey) {
       horizontal = !e.shiftKey;
+      if (horizontal) delta = -12 * e.deltaY;
+      else delta = -6 * e.deltaY;
+    } else if (Math.abs(e.deltaY) < Math.abs(e.deltaX)) {
+      horizontal = !e.shiftKey;
+      delta = e.deltaX;
     } else {
-      delta = e.deltaY;
       horizontal = e.shiftKey;
+      delta = e.deltaY;
     }
 
-    if (!e.altKey && !horizontal) {
+    if (!e.altKey && !e.ctrlKey && !horizontal) {
       // vertical scroll (native)
       updateVScrollAnchorInfo(e.clientY);
       return;
@@ -331,7 +335,7 @@ function MainViewer(props: MainViewerProps) {
     if (e.clientX > (anImgBoundngRect?.right ?? 0) || e.clientX < (anImgBoundngRect?.x ?? 0))
       return;
 
-    if (e.altKey) {
+    if (e.ctrlKey || e.altKey) {
       // zoom
       if (horizontal) {
         // horizontal zoom

--- a/src/renderer/prototypes/MainViewer/MainViewer.tsx
+++ b/src/renderer/prototypes/MainViewer/MainViewer.tsx
@@ -44,7 +44,7 @@ import {
   BIG_SHIFT_PX,
   SHIFT_PX,
 } from "../constants/tracks";
-import {isCommand, isCommandOnly} from "../../utils/commandKey";
+import {isApple, isCommand, isCommandOnly} from "../../utils/osSpecifics";
 
 type MainViewerProps = {
   trackIds: number[];
@@ -311,7 +311,8 @@ function MainViewer(props: MainViewerProps) {
 
     let horizontal: boolean;
     let delta: number;
-    if (e.ctrlKey) {
+    const isApplePinch = isApple() && e.ctrlKey;
+    if (isApplePinch) {
       horizontal = !e.shiftKey;
       if (horizontal) delta = -12 * e.deltaY;
       else delta = -6 * e.deltaY;
@@ -323,7 +324,7 @@ function MainViewer(props: MainViewerProps) {
       delta = e.deltaY;
     }
 
-    if (!e.altKey && !e.ctrlKey && !horizontal) {
+    if (!e.altKey && !isApplePinch && !horizontal) {
       // vertical scroll (native)
       updateVScrollAnchorInfo(e.clientY);
       return;
@@ -335,7 +336,7 @@ function MainViewer(props: MainViewerProps) {
     if (e.clientX > (anImgBoundngRect?.right ?? 0) || e.clientX < (anImgBoundngRect?.x ?? 0))
       return;
 
-    if (e.ctrlKey || e.altKey) {
+    if (isApplePinch || e.altKey) {
       // zoom
       if (horizontal) {
         // horizontal zoom

--- a/src/renderer/utils/osSpecifics.ts
+++ b/src/renderer/utils/osSpecifics.ts
@@ -1,4 +1,4 @@
-function isApple() {
+export function isApple() {
   const expression = /(Mac|iPhone|iPod|iPad)/i;
   return expression.test(navigator.platform);
 }


### PR DESCRIPTION
Apple trackpad pinch gestures trigger onWheel event with e.ctrlKey == true.

In cross-platform apps, ctrl key of macOS should not be reserved for regular key commands because ctrl key of Windows should be treated the same as command key of macOS.

Therefore, supporting pinch gesture by supporting ctrl+wheel **only on macOS** will have no problems.

To do that, I renamed commandKey.ts -> osSpecifics.ts.