### PR TITLE
rewrite player pipeline with cpal and state events & bump rubato version to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.10.0",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -768,11 +768,11 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
  "coreaudio-rs",
@@ -797,13 +797,17 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
+ "objc2",
  "objc2-audio-toolbox",
+ "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows",
 ]
 
 [[package]]
@@ -1183,15 +1187,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "endi"
@@ -2307,17 +2302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kittyaudio"
-version = "0.2.0"
-source = "git+https://github.com/Sytronik/kittyaudio.git?rev=549b6764da73724336b7539cf773b653c01d9420#549b6764da73724336b7539cf773b653c01d9420"
-dependencies = [
- "cpal",
- "parking_lot",
- "symphonia 0.5.5",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,9 +2440,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -2835,6 +2819,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,6 +2849,7 @@ dependencies = [
  "objc2",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2885,7 +2880,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -4610,40 +4607,17 @@ version = "0.5.4"
 source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428ffa638a0adabfacc676ca#2846716d4fa875e0428ffa638a0adabfacc676ca"
 dependencies = [
  "lazy_static",
- "symphonia-bundle-flac 0.5.4",
- "symphonia-bundle-mp3 0.5.4",
- "symphonia-codec-aac 0.5.4",
- "symphonia-codec-alac 0.5.4",
- "symphonia-codec-pcm 0.5.4",
- "symphonia-codec-vorbis 0.5.4",
- "symphonia-core 0.5.4",
- "symphonia-format-isomp4 0.5.4",
- "symphonia-format-ogg 0.5.4",
- "symphonia-format-riff 0.5.4",
- "symphonia-metadata 0.5.4",
-]
-
-[[package]]
-name = "symphonia"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
-dependencies = [
- "lazy_static",
- "symphonia-bundle-flac 0.5.5",
- "symphonia-bundle-mp3 0.5.5",
- "symphonia-codec-aac 0.5.5",
- "symphonia-codec-adpcm",
- "symphonia-codec-alac 0.5.5",
- "symphonia-codec-pcm 0.5.5",
- "symphonia-codec-vorbis 0.5.5",
- "symphonia-core 0.5.5",
- "symphonia-format-caf",
- "symphonia-format-isomp4 0.5.5",
- "symphonia-format-mkv",
- "symphonia-format-ogg 0.5.5",
- "symphonia-format-riff 0.5.5",
- "symphonia-metadata 0.5.5",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4653,20 +4627,8 @@ source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428
 dependencies = [
  "log",
  "symphonia-common",
- "symphonia-core 0.5.4",
- "symphonia-metadata 0.5.4",
-]
-
-[[package]]
-name = "symphonia-bundle-flac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
- "symphonia-utils-xiph",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4676,19 +4638,7 @@ source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428
 dependencies = [
  "lazy_static",
  "log",
- "symphonia-core 0.5.4",
-]
-
-[[package]]
-name = "symphonia-bundle-mp3"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -4698,28 +4648,7 @@ source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428
 dependencies = [
  "lazy_static",
  "log",
- "symphonia-core 0.5.4",
-]
-
-[[package]]
-name = "symphonia-codec-aac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core 0.5.5",
-]
-
-[[package]]
-name = "symphonia-codec-adpcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -4728,17 +4657,7 @@ version = "0.5.4"
 source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428ffa638a0adabfacc676ca#2846716d4fa875e0428ffa638a0adabfacc676ca"
 dependencies = [
  "log",
- "symphonia-core 0.5.4",
-]
-
-[[package]]
-name = "symphonia-codec-alac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -4747,17 +4666,7 @@ version = "0.5.4"
 source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428ffa638a0adabfacc676ca#2846716d4fa875e0428ffa638a0adabfacc676ca"
 dependencies = [
  "log",
- "symphonia-core 0.5.4",
-]
-
-[[package]]
-name = "symphonia-codec-pcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -4767,18 +4676,7 @@ source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428
 dependencies = [
  "log",
  "symphonia-common",
- "symphonia-core 0.5.4",
-]
-
-[[package]]
-name = "symphonia-codec-vorbis"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
- "symphonia-utils-xiph",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -4787,8 +4685,8 @@ version = "0.5.4"
 source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428ffa638a0adabfacc676ca#2846716d4fa875e0428ffa638a0adabfacc676ca"
 dependencies = [
  "log",
- "symphonia-core 0.5.4",
- "symphonia-metadata 0.5.4",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4806,64 +4704,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "symphonia-core"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "bytemuck",
- "lazy_static",
- "log",
-]
-
-[[package]]
-name = "symphonia-format-caf"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
-]
-
-[[package]]
 name = "symphonia-format-isomp4"
 version = "0.5.4"
 source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428ffa638a0adabfacc676ca#2846716d4fa875e0428ffa638a0adabfacc676ca"
 dependencies = [
  "log",
  "symphonia-common",
- "symphonia-core 0.5.4",
- "symphonia-metadata 0.5.4",
-]
-
-[[package]]
-name = "symphonia-format-isomp4"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
-dependencies = [
- "encoding_rs",
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-mkv"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
- "symphonia-utils-xiph",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4873,20 +4721,8 @@ source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428
 dependencies = [
  "log",
  "symphonia-common",
- "symphonia-core 0.5.4",
- "symphonia-metadata 0.5.4",
-]
-
-[[package]]
-name = "symphonia-format-ogg"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
-dependencies = [
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
- "symphonia-utils-xiph",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4896,20 +4732,8 @@ source = "git+https://github.com/pdeljanov/Symphonia.git?rev=2846716d4fa875e0428
 dependencies = [
  "extended",
  "log",
- "symphonia-core 0.5.4",
- "symphonia-metadata 0.5.4",
-]
-
-[[package]]
-name = "symphonia-format-riff"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
-dependencies = [
- "extended",
- "log",
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4921,29 +4745,7 @@ dependencies = [
  "log",
  "regex-lite",
  "smallvec",
- "symphonia-core 0.5.4",
-]
-
-[[package]]
-name = "symphonia-metadata"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
-dependencies = [
- "encoding_rs",
- "lazy_static",
- "log",
- "symphonia-core 0.5.5",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core 0.5.5",
- "symphonia-metadata 0.5.5",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -5044,7 +4846,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5133,7 +4935,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -5319,7 +5121,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.17",
  "url",
- "windows 0.61.3",
+ "windows",
  "zbus",
 ]
 
@@ -5410,7 +5212,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -5436,7 +5238,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -5530,7 +5332,6 @@ dependencies = [
  "hound",
  "identity-hash",
  "itertools 0.14.0",
- "kittyaudio",
  "log",
  "mimalloc",
  "ndarray",
@@ -5543,9 +5344,10 @@ dependencies = [
  "rayon",
  "readonly",
  "realfft",
+ "rubato",
  "serde",
  "serde_json",
- "symphonia 0.5.4",
+ "symphonia",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
@@ -6411,7 +6213,7 @@ checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6435,7 +6237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
  "thiserror 2.0.17",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
 ]
 
@@ -6487,16 +6289,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -6515,16 +6307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6617,15 +6399,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6983,7 +6756,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25c5bb54993ad4693d8b68b6f29f872c5fd9f92a6469d0acb0cbaf80a13d0f9"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6af89882334c4e501faa08992888593ada468f9e1ab211635c32f9ada7786e0"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9a3d502fec0b21aa420febe0b110875cf8a7057c49e83a0cace1df6a73e03e"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,14 +4045,18 @@ dependencies = [
 
 [[package]]
 name = "rubato"
-version = "0.16.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+checksum = "90173154a8a14e6adb109ea641743bc95ec81c093d94e70c6763565f7108ebeb"
 dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
  "num-complex",
  "num-integer",
  "num-traits",
  "realfft",
+ "visibility",
+ "windowfunctions",
 ]
 
 [[package]]
@@ -5323,6 +5364,7 @@ dependencies = [
  "anyhow",
  "approx",
  "atomic_float",
+ "audioadapter-buffers",
  "blas-src",
  "const_format",
  "cpal",
@@ -5381,6 +5423,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "atomic_float",
+ "audioadapter-buffers",
  "chrono",
  "fast_image_resize",
  "js-sys",
@@ -5952,6 +5995,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6285,6 +6339,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.14.0"
 ndarray = "0.17.1"
 num-traits = "0.2.19"
 parking_lot = "0.12.5"
+rubato = "0.16.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,13 @@ version = "0.1.0"
 # Shared dependencies that can be inherited by workspace members
 [workspace.dependencies]
 approx = "0.5.1"
+audioadapter-buffers = "2.0.0"
 atomic_float = "1.1.0"
 itertools = "0.14.0"
 ndarray = "0.17.1"
 num-traits = "0.2.19"
 parking_lot = "0.12.5"
-rubato = "0.16.2"
+rubato = "1.0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2", features = ["codegen"] }
 [dependencies]
 # console-subscriber = "0.4.0"
 anyhow = "1"
+audioadapter-buffers = { workspace = true }
 atomic_float = { workspace = true }
 const_format = "0.2.35"
 cpal = "0.17.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tauri-build = { version = "2", features = ["codegen"] }
 anyhow = "1"
 atomic_float = { workspace = true }
 const_format = "0.2.35"
-cpal = "0.16.0"
+cpal = "0.17.3"
 crossbeam-channel = "0.5.15"
 dunce = "1.0.5"
 ebur128 = "0.1.10"
@@ -38,6 +38,7 @@ parking_lot = { workspace = true }
 rayon = "1.11.0"
 readonly = "0.2.13"
 realfft = "3.5.0"
+rubato = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { version = "2", features = ["protocol-asset"] }
@@ -50,10 +51,6 @@ tauri-plugin-store = "2"
 thesia-common = { path = "../src-common" }
 tokio = "1"
 tokio-rayon = "2.1.0"
-
-[dependencies.kittyaudio]
-git = "https://github.com/Sytronik/kittyaudio.git"
-rev = "549b6764da73724336b7539cf773b653c01d9420"
 
 [dependencies.symphonia]
 default-features = false

--- a/src-tauri/src/core/audio.rs
+++ b/src-tauri/src/core/audio.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use kittyaudio::Frame;
 use ndarray::prelude::*;
 use rayon::prelude::*;
 use serde::Deserialize;
@@ -178,19 +177,17 @@ impl GuardClipping<Ix2> for Audio {
     }
 }
 
-impl From<&Audio> for Vec<Frame> {
-    fn from(value: &Audio) -> Self {
-        value
-            .view()
-            .axis_iter(Axis(1))
-            .map(|frame| {
-                match frame.len() {
-                    1 => frame[0].into(),
-                    2 => (frame[0], frame[1]).into(),
-                    _ => unimplemented!(), // TODO
-                }
-            })
-            .collect()
+impl Audio {
+    pub fn interleaved_samples(&self) -> Vec<f32> {
+        let n_ch = self.wavs.shape()[0];
+        let n_sample = self.wavs.shape()[1];
+        let mut samples = Vec::with_capacity(n_ch * n_sample);
+        for i in 0..n_sample {
+            for ch in 0..n_ch {
+                samples.push(self.wavs[(ch, i)]);
+            }
+        }
+        samples
     }
 }
 

--- a/src-tauri/src/core/track.rs
+++ b/src-tauri/src/core/track.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use identity_hash::{IntMap, IntSet};
-use kittyaudio::Frame;
 use ndarray::prelude::*;
 use rayon::prelude::*;
 use symphonia::core::errors::Error as SymphoniaError;
@@ -94,8 +93,8 @@ impl AudioTrack {
         self.audio.channel(ch)
     }
 
-    pub fn interleaved_frames(&self) -> Vec<Frame> {
-        self.audio.as_ref().into()
+    pub fn interleaved_samples(&self) -> Vec<f32> {
+        self.audio.interleaved_samples()
     }
 
     #[inline]

--- a/src-tauri/src/interface.rs
+++ b/src-tauri/src/interface.rs
@@ -100,14 +100,6 @@ pub struct ConstsAndUserSettings {
     pub user_settings: UserSettings,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PlayerState {
-    pub is_playing: bool,
-    pub position_sec: f64,
-    pub err: String,
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Spectrogram<'a> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ mod player;
 
 use core::*;
 use interface::*;
-use player::{PlayerCommand, PlayerNotification};
+use player::PlayerCommand;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags, WindowExt};
 
 #[cfg(all(
@@ -83,7 +83,7 @@ fn init(app: AppHandle, colormap_length: u32) -> tauri::Result<ConstsAndUserSett
     let settings_json = json!(user_settings);
     _set_user_settings(&app, settings_json, false)?;
 
-    player::spawn_task();
+    player::spawn_task(app);
     Ok(ConstsAndUserSettings {
         constants: Default::default(),
         user_settings,
@@ -498,22 +498,6 @@ async fn resume_player() {
     player::send(PlayerCommand::Resume).await;
 }
 
-#[tauri::command]
-fn get_player_state() -> PlayerState {
-    match player::recv() {
-        PlayerNotification::Ok(state) => PlayerState {
-            is_playing: state.is_playing,
-            position_sec: state.position_sec,
-            err: "".to_string(),
-        },
-        PlayerNotification::Err(e_str) => PlayerState {
-            is_playing: false,
-            position_sec: 0.,
-            err: e_str,
-        },
-    }
-}
-
 #[inline]
 async fn _refresh_track_player() {
     player::send(PlayerCommand::SetTrack((None, None))).await;
@@ -761,7 +745,6 @@ pub fn run() {
             seek_player,
             pause_player,
             resume_player,
-            get_player_state,
             menu::enable_edit_menu,
             menu::disable_edit_menu,
             menu::enable_axis_zoom_menu,

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -1,24 +1,29 @@
-use std::cell::RefCell;
-use std::sync::OnceLock;
-use std::sync::atomic::{self, AtomicU32, AtomicUsize};
+mod device;
+mod state;
+mod stream;
+
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
-use atomic_float::AtomicF32;
-use cpal::{SupportedStreamConfigsError, traits::DeviceTrait};
-use kittyaudio::{Device, KaError, Mixer, Sound, SoundHandle, StreamSettings};
-use log::{error, info};
+use log::{info, warn};
+use tauri::AppHandle;
 use tauri::async_runtime::spawn_blocking;
 use tokio::sync::mpsc::{self, error::TryRecvError};
-use tokio::sync::watch;
 
-use crate::{DeciBel, TRACK_LIST};
+use crate::DeciBel;
+use device::default_output_device_name;
+use state::{
+    SharedPlayback, StateEmitter, pause, position_sec, resume, seek, set_error, set_track,
+};
+use stream::{OutputStreamState, rebuild_stream};
 
 pub const PLAY_JUMP_SEC: f64 = 1.0;
 pub const PLAY_BIG_JUMP_SEC: f64 = 5.0;
-const PLAYER_NOTI_INTERVAL: Duration = Duration::from_millis(100);
+
+const PLAYER_LOOP_INTERVAL: Duration = Duration::from_millis(20);
+const DEVICE_CHECK_INTERVAL: Duration = Duration::from_millis(500);
 
 static COMMAND_TX: OnceLock<mpsc::Sender<PlayerCommand>> = OnceLock::new();
-static NOTI_RX: OnceLock<watch::Receiver<PlayerNotification>> = OnceLock::new();
 
 pub enum PlayerCommand {
     /// only caused by refreshing of frontend
@@ -38,42 +43,6 @@ pub enum PlayerCommand {
     Resume,
 }
 
-#[derive(Clone, Debug)]
-pub struct InternalPlayerState {
-    /// if currently playing
-    pub is_playing: bool,
-    /// playing position (sec)
-    pub position_sec: f64,
-    /// timestamp when this state is created
-    pub instant: Instant,
-}
-
-impl InternalPlayerState {
-    pub fn position_sec_elapsed(&self) -> f64 {
-        if self.is_playing {
-            self.position_sec + self.instant.elapsed().as_secs_f64()
-        } else {
-            self.position_sec
-        }
-    }
-}
-
-impl Default for InternalPlayerState {
-    fn default() -> Self {
-        InternalPlayerState {
-            is_playing: false,
-            position_sec: 0.,
-            instant: Instant::now(),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub enum PlayerNotification {
-    Ok(InternalPlayerState),
-    Err(String),
-}
-
 pub async fn send(msg: PlayerCommand) {
     let msg_tx = COMMAND_TX.get().unwrap().clone();
     if let Err(e) = msg_tx.send(msg).await {
@@ -81,364 +50,133 @@ pub async fn send(msg: PlayerCommand) {
     }
 }
 
-pub fn recv() -> PlayerNotification {
-    let noti_rx = NOTI_RX.get().unwrap();
-    let noti = (noti_rx.borrow()).clone();
-    match noti {
-        PlayerNotification::Ok(mut state) if state.is_playing => {
-            state.position_sec = state.position_sec_elapsed();
-            PlayerNotification::Ok(state)
-        }
-        _ => noti,
-    }
-}
+fn main_loop(mut msg_rx: mpsc::Receiver<PlayerCommand>, app: AppHandle) {
+    let shared = Arc::new(SharedPlayback::default());
 
-fn get_supported_sr_list(device_name: &str) -> Result<Vec<u32>, KaError> {
-    if let Device::Custom(device) = Device::from_name(device_name)? {
-        match device.supported_output_configs() {
-            Ok(supported_configs) => Ok(supported_configs
-                .flat_map(|c| c.min_sample_rate().0..=c.max_sample_rate().0)
-                .collect()),
-            Err(SupportedStreamConfigsError::DeviceNotAvailable) => Err(KaError::BuildStreamError(
-                cpal::BuildStreamError::DeviceNotAvailable,
-            )),
-            Err(SupportedStreamConfigsError::InvalidArgument) => Err(KaError::BuildStreamError(
-                cpal::BuildStreamError::InvalidArgument,
-            )),
-            Err(SupportedStreamConfigsError::BackendSpecific { err }) => Err(
-                KaError::BuildStreamError(cpal::BuildStreamError::BackendSpecific { err }),
-            ),
-        }
-    } else {
-        unreachable!();
-    }
-}
+    let mut requested_sr: Option<u32> = None;
+    let mut stream_state: Option<OutputStreamState> = None;
+    let mut current_error = String::new();
+    let mut state_emitter = StateEmitter::default();
+    let mut last_device_check = Instant::now();
 
-fn get_optimal_sr(device_name: &str, sr: u32) -> Result<Option<u32>, KaError> {
-    if sr == 0 {
-        return Ok(None);
-    }
-    let supported_sr_list = get_supported_sr_list(device_name)?;
-    info!("supported sr: {:?}", supported_sr_list);
-    if supported_sr_list.contains(&sr) {
-        return Ok(Some(sr));
-    }
-    let (closest_greater, closest_less) = supported_sr_list.into_iter().fold(
-        (u32::MAX, 0),
-        |(closest_greater, closest_less), curr_sr| {
-            if curr_sr >= sr {
-                if curr_sr - sr < closest_greater - sr {
-                    return (curr_sr, closest_less);
-                }
-                return (closest_greater, closest_less);
-            }
-            if sr - curr_sr < sr - closest_less {
-                return (closest_greater, curr_sr);
-            }
-            (closest_greater, closest_less)
-        },
-    );
-    if closest_greater < u32::MAX {
-        Ok(Some(closest_greater))
-    } else if closest_less > 0 {
-        Ok(Some(closest_less))
-    } else {
-        Ok(None)
-    }
-}
-
-fn calc_position_sec(sound_handle: &SoundHandle) -> f64 {
-    sound_handle.index() as f64 / sound_handle.sample_rate() as f64
-}
-
-fn noti_err(noti_tx: &watch::Sender<PlayerNotification>, err: KaError) {
-    error!("{}", err);
-    noti_tx
-        .send(PlayerNotification::Err(err.to_string()))
-        .unwrap();
-}
-
-fn main_loop(
-    mut msg_rx: mpsc::Receiver<PlayerCommand>,
-    noti_tx: watch::Sender<PlayerNotification>,
-) {
-    let current_sr = AtomicU32::new(48000);
-    let current_volume = AtomicF32::new(1.);
-    let current_track_id = AtomicUsize::new(0);
-    let get_device_name = || {
-        Device::Default.name().unwrap_or_else(|err| {
-            noti_err(&noti_tx, err);
-            "".into()
-        })
-    };
-    let device_name = RefCell::new("".into());
-    let init_mixer = |sr: Option<u32>, change_device: bool| {
-        let sr = sr.unwrap_or(48000);
-        let mixer = Mixer::new();
-        if change_device {
-            *device_name.borrow_mut() = get_device_name();
-        }
-        let device = loop {
-            match Device::from_name(&device_name.borrow()) {
-                Ok(d) => break d,
-                Err(err) => {
-                    noti_err(&noti_tx, err);
-                    std::thread::sleep(Duration::from_secs(1));
-                    *device_name.borrow_mut() = get_device_name();
-                }
-            };
-        };
-        mixer.init_ex(
-            device,
-            StreamSettings {
-                sample_rate: Some(sr),
-                ..Default::default()
-            },
-        );
-        info!("device: {}, sr: {}", device_name.borrow(), sr);
-        current_sr.store(sr, atomic::Ordering::Release);
-        mixer
-    };
-    let mut mixer = init_mixer(None, true);
-    let mut sound_handle = SoundHandle::new({
-        let mut sound = Sound::default();
-        sound.pause();
-        sound
-    });
-    let set_track = |mixer: &mut Mixer,
-                     sound_handle: &mut SoundHandle,
-                     track_id: Option<usize>,
-                     start_time_sec: f64,
-                     is_playing: bool| {
-        let track_id = track_id.unwrap_or(current_track_id.load(atomic::Ordering::Acquire));
-        let sound = TRACK_LIST
-            .read()
-            .get(track_id)
-            .map(|track| Sound::new(track.sr(), track.interleaved_frames().into()));
-
-        info!("sound created with track {}", track_id);
-        match sound {
-            Some(mut sound) => {
-                sound.paused = !is_playing;
-                sound.set_volume(current_volume.load(atomic::Ordering::Acquire));
-                sound.seek_to(start_time_sec);
-                mixer.renderer.guard().sounds.clear();
-                info!("mixer clear");
-                *sound_handle = mixer.play(sound);
-                info!("sound added");
-                current_track_id.store(track_id, atomic::Ordering::Release);
-            }
-            None => {
-                mixer.renderer.guard().sounds.clear();
-                info!("mixer clear");
-            }
-        }
-    };
+    let mut should_emit =
+        rebuild_stream(&shared, requested_sr, &mut stream_state, &mut current_error);
 
     loop {
-        match msg_rx.try_recv() {
-            Ok(msg) => match msg {
-                PlayerCommand::Initialize => {
-                    mixer = init_mixer(None, true);
-                }
-                PlayerCommand::SetSr(sr) if current_sr.load(atomic::Ordering::Acquire) != sr => {
-                    let sr = match get_optimal_sr(&device_name.borrow(), sr) {
-                        Ok(sr) => sr,
-                        Err(err) => {
-                            noti_err(&noti_tx, err);
-                            continue;
-                        }
-                    };
-                    if sr.is_some_and(|sr| sr != current_sr.load(atomic::Ordering::Acquire))
-                        || sr.is_none()
-                    {
-                        mixer = init_mixer(sr, false);
-                    } else {
-                        info!("sr no change");
-                    }
-                }
-                PlayerCommand::SetSr(_) => {
-                    info!("sr no change");
-                }
-                #[allow(non_snake_case)]
-                PlayerCommand::SetVolumedB(volume_dB) => {
-                    let volume = volume_dB.amp_from_dB_default() as f32;
-                    current_volume.store(volume, atomic::Ordering::Release);
-                    sound_handle.set_volume(volume);
-                }
-                PlayerCommand::SetTrack((track_id, start_time)) => {
-                    info!("set track");
-                    let (start_time, is_playing) =
-                        if let PlayerNotification::Ok(state) = &(*noti_tx.borrow()) {
-                            (
-                                start_time.unwrap_or(state.position_sec_elapsed()),
-                                state.is_playing,
-                            )
-                        } else {
-                            (0., false)
-                        };
-                    set_track(
-                        &mut mixer,
-                        &mut sound_handle,
-                        track_id,
-                        start_time,
-                        is_playing,
-                    );
-                }
-                PlayerCommand::Seek(sec) => {
-                    let max_sec = TRACK_LIST.read().max_sec;
-                    let sec = sec.min(max_sec);
-                    noti_tx.send_modify(|noti| {
-                        if let PlayerNotification::Ok(state) = noti {
-                            if state.is_playing && mixer.is_finished() {
-                                set_track(
-                                    &mut mixer,
-                                    &mut sound_handle,
-                                    Some(current_track_id.load(atomic::Ordering::Acquire)),
-                                    sec,
-                                    state.is_playing,
-                                );
-                            } else {
-                                sound_handle.seek_to(sec);
-                            }
-                            state.position_sec = sec;
-                            state.instant = Instant::now();
-                        }
-                    });
-                    info!("seek to {}", sec);
-                }
-                PlayerCommand::Pause => {
-                    sound_handle.pause();
-                    if matches!(*noti_tx.borrow(), PlayerNotification::Ok(_)) {
-                        noti_tx
-                            .send(PlayerNotification::Ok(InternalPlayerState {
-                                is_playing: false,
-                                position_sec: calc_position_sec(&sound_handle),
-                                instant: Instant::now(),
-                            }))
-                            .unwrap();
-                    }
-                    info!("pause");
-                }
-                PlayerCommand::Resume => {
-                    sound_handle.resume();
-
-                    let position_sec = if let PlayerNotification::Ok(state) = &(*noti_tx.borrow()) {
-                        state.position_sec
-                    } else {
-                        0.
-                    };
-                    if mixer.is_finished() {
-                        set_track(&mut mixer, &mut sound_handle, None, position_sec, true);
-                    }
-                    if matches!(*noti_tx.borrow(), PlayerNotification::Ok(_)) {
-                        noti_tx
-                            .send(PlayerNotification::Ok(InternalPlayerState {
-                                is_playing: true,
-                                position_sec,
-                                instant: Instant::now(),
-                            }))
-                            .unwrap();
-                    }
-                    info!("play");
-                }
-            },
-            Err(TryRecvError::Empty) => {
-                // TODO: error handling
-                // if !mixer.backend.is_locked() {
-                //     mixer.handle_errors(|err| {
-                //         noti_err(&noti_tx, KaError::StreamError(err));
-                //     });
-                //     mixer = init_mixer(Some(current_sr.load(atomic::Ordering::Acquire)));
-                // }
-                // notification
-                let prev_state = if let PlayerNotification::Ok(state) = &(*noti_tx.borrow()) {
-                    Some(state.clone())
-                } else {
-                    None
-                };
-                if let Some(prev_state) = prev_state {
-                    let mut state = InternalPlayerState {
-                        is_playing: prev_state.is_playing,
-                        position_sec: calc_position_sec(&sound_handle),
-                        instant: Instant::now(),
-                    };
-                    if mixer.is_finished() {
-                        // no current sound
-                        {
-                            // only for logging
-                            if !sound_handle.paused() {
-                                sound_handle.pause();
-                                info!("track ended");
-                            }
-                        }
-                        let position_sec = prev_state.position_sec
-                            + (state.instant - prev_state.instant).as_secs_f64();
-                        let max_sec = TRACK_LIST.read().max_sec;
-                        if position_sec >= max_sec {
-                            state.is_playing = false;
-                            state.position_sec = max_sec;
-                            if prev_state.position_sec != max_sec {
-                                info!("reached max_sec {}", max_sec);
-                            }
-                        } else if prev_state.is_playing {
-                            state.is_playing = true;
-                            state.position_sec = position_sec;
-                        } else {
-                            state.is_playing = false;
-                            state.position_sec = prev_state.position_sec;
-                        }
-                    }
-                    noti_tx.send(PlayerNotification::Ok(state)).unwrap();
-                }
-                let new_device = Device::Default.name();
-                if let Ok(new_device) = new_device
-                    && new_device != *device_name.borrow()
-                {
-                    let sr = match get_optimal_sr(
-                        &new_device,
-                        current_sr.load(atomic::Ordering::Acquire),
-                    ) {
-                        Ok(sr) => sr,
-                        Err(err) => {
-                            noti_err(&noti_tx, err);
-                            continue;
-                        }
-                    };
-                    mixer = init_mixer(sr, true);
-                    sound_handle.pause();
-
-                    let state = if let PlayerNotification::Ok(state) = &(*noti_tx.borrow()) {
-                        Some(state.clone())
-                    } else {
-                        None
-                    };
-                    if let Some(state) = state {
-                        set_track(
-                            &mut mixer,
-                            &mut sound_handle,
-                            Some(current_track_id.load(atomic::Ordering::Acquire)),
-                            state.position_sec_elapsed(),
-                            state.is_playing,
+        loop {
+            match msg_rx.try_recv() {
+                Ok(msg) => match msg {
+                    PlayerCommand::Initialize => {
+                        should_emit |= rebuild_stream(
+                            &shared,
+                            requested_sr,
+                            &mut stream_state,
+                            &mut current_error,
                         );
                     }
-                    continue;
-                }
-                std::thread::sleep(PLAYER_NOTI_INTERVAL);
-            }
-            Err(TryRecvError::Disconnected) => {
-                break;
+                    PlayerCommand::SetSr(sr) => {
+                        let new_requested_sr = (sr != 0).then_some(sr);
+                        if new_requested_sr != requested_sr || stream_state.is_none() {
+                            requested_sr = new_requested_sr;
+                            should_emit |= rebuild_stream(
+                                &shared,
+                                requested_sr,
+                                &mut stream_state,
+                                &mut current_error,
+                            );
+                        } else {
+                            info!("sr no change");
+                        }
+                    }
+                    #[allow(non_snake_case)]
+                    PlayerCommand::SetVolumedB(volume_dB) => {
+                        let volume = volume_dB.amp_from_dB_default() as f32;
+                        shared.data.lock().volume = volume;
+                    }
+                    PlayerCommand::SetTrack((track_id, start_time)) => {
+                        let (current_position, is_playing) = {
+                            let playback = shared.data.lock();
+                            (position_sec(&playback), playback.is_playing)
+                        };
+                        let start_time = start_time.unwrap_or(current_position);
+                        set_track(&shared, track_id, start_time, is_playing);
+                        shared.clear_track_end();
+                        should_emit = true;
+                    }
+                    PlayerCommand::Seek(sec) => {
+                        seek(&shared, sec);
+                        shared.clear_track_end();
+                        should_emit = true;
+                    }
+                    PlayerCommand::Pause => {
+                        pause(&shared);
+                        should_emit = true;
+                    }
+                    PlayerCommand::Resume => {
+                        resume(&shared);
+                        should_emit = true;
+                    }
+                },
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => return,
             }
         }
+
+        if shared.take_track_end() {
+            info!("track ended");
+            should_emit = true;
+        }
+
+        if let Some(stream_error) = shared.take_stream_error() {
+            should_emit |= set_error(&mut current_error, Some(stream_error));
+            should_emit |=
+                rebuild_stream(&shared, requested_sr, &mut stream_state, &mut current_error);
+        }
+
+        if last_device_check.elapsed() >= DEVICE_CHECK_INTERVAL {
+            last_device_check = Instant::now();
+
+            if let Some(stream) = &stream_state {
+                match default_output_device_name() {
+                    Some(device_name) if device_name != stream.device_name => {
+                        warn!(
+                            "default output device changed: {} -> {}",
+                            stream.device_name, device_name
+                        );
+                        should_emit |= rebuild_stream(
+                            &shared,
+                            requested_sr,
+                            &mut stream_state,
+                            &mut current_error,
+                        );
+                    }
+                    Some(_) => {}
+                    None => {
+                        should_emit |= set_error(
+                            &mut current_error,
+                            Some("No default output device available".to_string()),
+                        );
+                        stream_state = None;
+                        shared.data.lock().is_playing = false;
+                    }
+                }
+            } else {
+                should_emit |=
+                    rebuild_stream(&shared, requested_sr, &mut stream_state, &mut current_error);
+            }
+        }
+
+        if should_emit {
+            state_emitter.emit_if_changed(&app, &shared, &current_error);
+            should_emit = false;
+        }
+
+        std::thread::sleep(PLAYER_LOOP_INTERVAL);
     }
 }
 
-pub fn spawn_task() {
-    if COMMAND_TX.get().is_some_and(|cmd_tx| !cmd_tx.is_closed())
-        && NOTI_RX
-            .get()
-            .is_some_and(|noti_rx| noti_rx.has_changed().is_ok())
-    {
+pub fn spawn_task(app: AppHandle) {
+    if COMMAND_TX.get().is_some_and(|cmd_tx| !cmd_tx.is_closed()) {
         COMMAND_TX
             .get()
             .unwrap()
@@ -448,8 +186,6 @@ pub fn spawn_task() {
     }
 
     let (command_tx, command_rx) = mpsc::channel::<PlayerCommand>(20);
-    let (noti_tx, noti_rx) = watch::channel(PlayerNotification::Ok(Default::default()));
     COMMAND_TX.set(command_tx).unwrap();
-    NOTI_RX.set(noti_rx).unwrap();
-    spawn_blocking(|| main_loop(command_rx, noti_tx));
+    spawn_blocking(move || main_loop(command_rx, app));
 }

--- a/src-tauri/src/player/device.rs
+++ b/src-tauri/src/player/device.rs
@@ -1,0 +1,83 @@
+use cpal::traits::{DeviceTrait, HostTrait};
+use cpal::{Device, SampleFormat, StreamConfig, SupportedStreamConfigRange};
+
+pub(super) fn default_output_device() -> Result<Device, String> {
+    cpal::default_host()
+        .default_output_device()
+        .ok_or_else(|| "No default output device available".to_string())
+}
+
+#[allow(deprecated)]
+pub(super) fn device_name(device: &Device) -> Option<String> {
+    device.name().ok()
+}
+
+pub(super) fn default_output_device_name() -> Option<String> {
+    default_output_device().ok().and_then(|d| device_name(&d))
+}
+
+fn nearest_sample_rate(range: &SupportedStreamConfigRange, target: u32) -> u32 {
+    target.clamp(range.min_sample_rate(), range.max_sample_rate())
+}
+
+pub(super) fn choose_stream_config(
+    device: &Device,
+    requested_sr: Option<u32>,
+) -> Result<(StreamConfig, SampleFormat, u32), String> {
+    let default_config = device
+        .default_output_config()
+        .map_err(|e| format!("Failed to get default output config: {}", e))?;
+    let default_format = default_config.sample_format();
+    let default_channels = default_config.channels();
+
+    if requested_sr.is_none() {
+        let config = default_config.config();
+        return Ok((config.clone(), default_format, config.sample_rate));
+    }
+
+    let target_sr = requested_sr.unwrap();
+    let ranges: Vec<_> = device
+        .supported_output_configs()
+        .map_err(|e| format!("Failed to query supported output configs: {}", e))?
+        .collect();
+
+    if ranges.is_empty() {
+        return Err("No supported output configs found".to_string());
+    }
+
+    let mut candidates: Vec<&SupportedStreamConfigRange> = ranges
+        .iter()
+        .filter(|x| x.channels() == default_channels && x.sample_format() == default_format)
+        .collect();
+    if candidates.is_empty() {
+        candidates = ranges
+            .iter()
+            .filter(|x| x.sample_format() == default_format)
+            .collect();
+    }
+    if candidates.is_empty() {
+        candidates = ranges.iter().collect();
+    }
+
+    let mut best: Option<(&SupportedStreamConfigRange, u32, u32, bool)> = None;
+    for range in candidates {
+        let sr = nearest_sample_rate(range, target_sr);
+        let diff = sr.abs_diff(target_sr);
+        let is_greater_or_eq = sr >= target_sr;
+        let should_replace = match best {
+            None => true,
+            Some((_, _, best_diff, best_is_greater_or_eq)) => {
+                diff < best_diff
+                    || (diff == best_diff && is_greater_or_eq && !best_is_greater_or_eq)
+            }
+        };
+
+        if should_replace {
+            best = Some((range, sr, diff, is_greater_or_eq));
+        }
+    }
+
+    let (range, sample_rate, _, _) = best.unwrap();
+    let config = range.with_sample_rate(sample_rate).config();
+    Ok((config, range.sample_format(), sample_rate))
+}

--- a/src-tauri/src/player/state.rs
+++ b/src-tauri/src/player/state.rs
@@ -1,0 +1,266 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::TRACK_LIST;
+
+#[derive(Default)]
+pub(super) struct SharedPlayback {
+    pub(super) data: Mutex<PlaybackData>,
+    reached_track_end: AtomicBool,
+    stream_error: Mutex<Option<String>>,
+}
+
+impl SharedPlayback {
+    pub(super) fn mark_stream_error(&self, err: String) {
+        *self.stream_error.lock() = Some(err);
+    }
+
+    pub(super) fn take_stream_error(&self) -> Option<String> {
+        self.stream_error.lock().take()
+    }
+
+    pub(super) fn mark_track_end(&self) {
+        self.reached_track_end.store(true, Ordering::Release);
+    }
+
+    pub(super) fn take_track_end(&self) -> bool {
+        self.reached_track_end.swap(false, Ordering::AcqRel)
+    }
+
+    pub(super) fn clear_track_end(&self) {
+        self.reached_track_end.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct PlaybackData {
+    pub(super) track_id: Option<usize>,
+    pub(super) samples: Vec<f32>,
+    pub(super) input_channels: usize,
+    pub(super) sample_rate: u32,
+    pub(super) position_frame: f64,
+    pub(super) cursor_version: u64,
+    pub(super) volume: f32,
+    pub(super) is_playing: bool,
+}
+
+impl Default for PlaybackData {
+    fn default() -> Self {
+        Self {
+            track_id: None,
+            samples: Vec::new(),
+            input_channels: 0,
+            sample_rate: 0,
+            position_frame: 0.,
+            cursor_version: 0,
+            volume: 1.,
+            is_playing: false,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PlayerStateSnapshot {
+    is_playing: bool,
+    position_sec: f64,
+    track_id: Option<u32>,
+    err: String,
+}
+
+impl PlayerStateSnapshot {
+    fn is_same_state(&self, other: &Self, elapsed_since_self: Duration) -> bool {
+        if self.is_playing != other.is_playing
+            || self.track_id != other.track_id
+            || self.err != other.err
+        {
+            return false;
+        }
+
+        let expected_position_sec = if self.is_playing {
+            self.position_sec + elapsed_since_self.as_secs_f64()
+        } else {
+            self.position_sec
+        };
+
+        (expected_position_sec - other.position_sec).abs() < 1e-3
+    }
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PlayerStateEvent {
+    is_playing: bool,
+    position_sec: f64,
+    event_time_ms: u64,
+    track_id: Option<u32>,
+    err: String,
+}
+
+impl From<PlayerStateSnapshot> for PlayerStateEvent {
+    fn from(value: PlayerStateSnapshot) -> Self {
+        Self {
+            is_playing: value.is_playing,
+            position_sec: value.position_sec,
+            event_time_ms: now_millis(),
+            track_id: value.track_id,
+            err: value.err,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct StateEmitter {
+    last_snapshot: Option<PlayerStateSnapshot>,
+    last_emit_at: Option<Instant>,
+}
+
+impl StateEmitter {
+    pub(super) fn emit_if_changed(&mut self, app: &AppHandle, shared: &SharedPlayback, err: &str) {
+        let snapshot = snapshot_state(shared, err);
+        if let Some(prev) = self.last_snapshot.as_ref() {
+            let elapsed = self.last_emit_at.map_or(Duration::ZERO, |t| t.elapsed());
+            if prev.is_same_state(&snapshot, elapsed) {
+                return;
+            }
+        }
+        self.last_snapshot = Some(snapshot.clone());
+        self.last_emit_at = Some(Instant::now());
+
+        let event = PlayerStateEvent::from(snapshot);
+        if let Err(e) = app.emit("player-state-changed", event) {
+            log::error!("failed to emit player-state-changed: {}", e);
+        }
+    }
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub(super) fn position_sec(playback: &PlaybackData) -> f64 {
+    if playback.samples.is_empty() || playback.input_channels == 0 || playback.sample_rate == 0 {
+        return 0.;
+    }
+
+    let total_frames = playback.samples.len() / playback.input_channels;
+    playback.position_frame.clamp(0., total_frames as f64) / playback.sample_rate as f64
+}
+
+fn snapshot_state(shared: &SharedPlayback, err: &str) -> PlayerStateSnapshot {
+    let playback = shared.data.lock();
+    PlayerStateSnapshot {
+        is_playing: playback.is_playing,
+        position_sec: position_sec(&playback),
+        track_id: playback.track_id.map(|x| x as u32),
+        err: err.to_string(),
+    }
+}
+
+pub(super) fn set_error(current_error: &mut String, maybe_err: Option<String>) -> bool {
+    match maybe_err {
+        Some(err) => {
+            if *current_error == err {
+                false
+            } else {
+                *current_error = err;
+                true
+            }
+        }
+        None => {
+            if current_error.is_empty() {
+                false
+            } else {
+                current_error.clear();
+                true
+            }
+        }
+    }
+}
+
+pub(super) fn set_track(
+    shared: &Arc<SharedPlayback>,
+    track_id: Option<usize>,
+    start_time_sec: f64,
+    is_playing: bool,
+) {
+    let current_track_id = shared.data.lock().track_id;
+    let target_track_id = track_id.or(current_track_id);
+
+    let loaded_track = target_track_id.and_then(|id| {
+        TRACK_LIST.read().get(id).map(|track| {
+            (
+                id,
+                track.interleaved_samples(),
+                track.n_ch(),
+                track.sr(),
+                track.sec(),
+            )
+        })
+    });
+
+    let mut playback = shared.data.lock();
+    match loaded_track {
+        Some((track_id, samples, channels, sample_rate, max_sec)) => {
+            let start_sec = start_time_sec.clamp(0., max_sec.max(0.));
+            playback.track_id = Some(track_id);
+            playback.samples = samples;
+            playback.input_channels = channels;
+            playback.sample_rate = sample_rate;
+            playback.position_frame = start_sec * sample_rate as f64;
+            playback.cursor_version = playback.cursor_version.wrapping_add(1);
+            playback.is_playing = is_playing;
+            log::info!("set track {}", track_id);
+        }
+        None => {
+            playback.track_id = None;
+            playback.samples.clear();
+            playback.input_channels = 0;
+            playback.sample_rate = 0;
+            playback.position_frame = 0.;
+            playback.cursor_version = playback.cursor_version.wrapping_add(1);
+            playback.is_playing = false;
+            log::info!("clear track");
+        }
+    }
+}
+
+pub(super) fn seek(shared: &Arc<SharedPlayback>, sec: f64) {
+    let sec = sec.clamp(0., TRACK_LIST.read().max_sec.max(0.));
+    let mut playback = shared.data.lock();
+
+    if playback.sample_rate == 0 || playback.input_channels == 0 || playback.samples.is_empty() {
+        playback.position_frame = 0.;
+        return;
+    }
+
+    let total_frames = playback.samples.len() / playback.input_channels;
+    let max_sec = total_frames as f64 / playback.sample_rate as f64;
+    let sec = sec.min(max_sec);
+    playback.position_frame = sec * playback.sample_rate as f64;
+    playback.cursor_version = playback.cursor_version.wrapping_add(1);
+
+    log::info!("seek to {}", sec);
+}
+
+pub(super) fn pause(shared: &Arc<SharedPlayback>) {
+    shared.data.lock().is_playing = false;
+    log::info!("pause");
+}
+
+pub(super) fn resume(shared: &Arc<SharedPlayback>) {
+    let mut playback = shared.data.lock();
+    if playback.track_id.is_some() && !playback.samples.is_empty() {
+        playback.is_playing = true;
+    }
+    log::info!("resume");
+}

--- a/src-tauri/src/player/stream.rs
+++ b/src-tauri/src/player/stream.rs
@@ -281,6 +281,14 @@ where
     }
 }
 
+fn playback_total_frames(playback: &PlaybackData) -> usize {
+    if playback.input_channels == 0 {
+        0
+    } else {
+        playback.samples.len() / playback.input_channels
+    }
+}
+
 fn fill_output_without_resampler<T, F>(
     data: &mut [T],
     output_channels: usize,
@@ -329,7 +337,6 @@ fn fill_output_with_rubato<T, F>(
     output_channels: usize,
     output_sample_rate: u32,
     playback: &mut PlaybackData,
-    total_frames: usize,
     render_state: &mut RenderState,
     shared: &SharedPlayback,
     convert: &F,
@@ -371,6 +378,7 @@ fn fill_output_with_rubato<T, F>(
         render_state.frame_buffer.resize(output_channels, 0.);
     }
 
+    let total_frames = playback_total_frames(playback);
     let step = playback.sample_rate as f64 / output_sample_rate as f64;
     let mut reached_end = false;
     let mut process_error: Option<(usize, String)> = None;
@@ -457,7 +465,7 @@ fn fill_output<T, F>(
         return;
     }
 
-    let total_frames = playback.samples.len() / playback.input_channels;
+    let total_frames = playback_total_frames(&playback);
     if total_frames == 0 {
         playback.is_playing = false;
         playback.position_frame = 0.;
@@ -484,7 +492,6 @@ fn fill_output<T, F>(
         output_channels,
         output_sample_rate,
         &mut playback,
-        total_frames,
         render_state,
         shared,
         &convert,
@@ -521,7 +528,7 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| x,
+                        std::convert::identity,
                     );
                 },
                 err_fn,
@@ -540,7 +547,7 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| <i16 as Sample>::from_sample(x),
+                        <i16 as Sample>::from_sample,
                     );
                 },
                 err_fn,
@@ -559,7 +566,7 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| <u16 as Sample>::from_sample(x),
+                        <u16 as Sample>::from_sample,
                     );
                 },
                 err_fn,
@@ -578,7 +585,7 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| <cpal::I24 as Sample>::from_sample(x),
+                        <cpal::I24 as Sample>::from_sample,
                     );
                 },
                 err_fn,
@@ -597,7 +604,7 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| <cpal::U24 as Sample>::from_sample(x),
+                        <cpal::U24 as Sample>::from_sample,
                     );
                 },
                 err_fn,

--- a/src-tauri/src/player/stream.rs
+++ b/src-tauri/src/player/stream.rs
@@ -1,0 +1,594 @@
+use std::sync::Arc;
+
+use cpal::traits::{DeviceTrait, StreamTrait};
+use cpal::{SampleFormat, Stream};
+use rubato::{
+    Resampler, SincFixedOut, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+    calculate_cutoff,
+};
+
+use super::device::{choose_stream_config, default_output_device, device_name};
+use super::state::{PlaybackData, SharedPlayback, set_error};
+
+const RUBATO_CHUNK_SIZE: usize = 1024;
+const RUBATO_SINC_LEN: usize = 256;
+const RUBATO_OVERSAMPLING: usize = 128;
+const RUBATO_MAX_GENERATE_ATTEMPTS: usize = 16;
+const RUBATO_QUEUE_COMPACT_THRESHOLD: usize = 8192;
+const RUBATO_WINDOW: WindowFunction = WindowFunction::BlackmanHarris2;
+
+pub(super) struct OutputStreamState {
+    _stream: Stream,
+    pub(super) device_name: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct RubatoConfigKey {
+    input_sample_rate: u32,
+    output_sample_rate: u32,
+    output_channels: usize,
+}
+
+struct RubatoStreamResampler {
+    key: RubatoConfigKey,
+    resampler: SincFixedOut<f32>,
+    input_buffer: Vec<Vec<f32>>,
+    output_buffer: Vec<Vec<f32>>,
+    queued_interleaved: Vec<f32>,
+    queued_offset: usize,
+    pending_delay_drop: usize,
+    input_cursor_frame: usize,
+    drain_chunks_left: usize,
+}
+
+impl RubatoStreamResampler {
+    fn new(
+        input_sample_rate: u32,
+        output_sample_rate: u32,
+        output_channels: usize,
+    ) -> Result<Self, String> {
+        if input_sample_rate == 0 || output_sample_rate == 0 {
+            return Err("Invalid sample rate for resampler".to_string());
+        }
+        if output_channels == 0 {
+            return Err("Invalid output channel count for resampler".to_string());
+        }
+
+        let ratio = output_sample_rate as f64 / input_sample_rate as f64;
+        let params = SincInterpolationParameters {
+            sinc_len: RUBATO_SINC_LEN,
+            f_cutoff: calculate_cutoff(RUBATO_SINC_LEN, RUBATO_WINDOW),
+            interpolation: SincInterpolationType::Cubic,
+            oversampling_factor: RUBATO_OVERSAMPLING,
+            window: RUBATO_WINDOW,
+        };
+        let resampler =
+            SincFixedOut::<f32>::new(ratio, 1.0, params, RUBATO_CHUNK_SIZE, output_channels)
+                .map_err(|e| format!("Failed to build rubato resampler: {}", e))?;
+        let pending_delay_drop = resampler.output_delay();
+        let input_buffer = resampler.input_buffer_allocate(true);
+        let output_buffer = resampler.output_buffer_allocate(true);
+
+        Ok(Self {
+            key: RubatoConfigKey {
+                input_sample_rate,
+                output_sample_rate,
+                output_channels,
+            },
+            resampler,
+            input_buffer,
+            output_buffer,
+            queued_interleaved: Vec::with_capacity(output_channels * RUBATO_CHUNK_SIZE * 4),
+            queued_offset: 0,
+            pending_delay_drop,
+            input_cursor_frame: 0,
+            drain_chunks_left: 0,
+        })
+    }
+
+    fn matches(
+        &self,
+        input_sample_rate: u32,
+        output_sample_rate: u32,
+        output_channels: usize,
+    ) -> bool {
+        self.key
+            == RubatoConfigKey {
+                input_sample_rate,
+                output_sample_rate,
+                output_channels,
+            }
+    }
+
+    fn reset_for_cursor(&mut self, position_frame: f64) {
+        self.resampler.reset();
+        self.pending_delay_drop = self.resampler.output_delay();
+        self.input_cursor_frame = position_frame.max(0.).floor() as usize;
+        self.drain_chunks_left = 0;
+        self.queued_interleaved.clear();
+        self.queued_offset = 0;
+    }
+
+    fn output_frames_available(&self) -> usize {
+        let available_samples = self
+            .queued_interleaved
+            .len()
+            .saturating_sub(self.queued_offset);
+        available_samples / self.key.output_channels
+    }
+
+    fn read_frame(&mut self, dst: &mut [f32]) -> bool {
+        if dst.len() < self.key.output_channels || self.output_frames_available() == 0 {
+            return false;
+        }
+        let start = self.queued_offset;
+        let end = start + self.key.output_channels;
+        dst[..self.key.output_channels].copy_from_slice(&self.queued_interleaved[start..end]);
+        self.queued_offset = end;
+
+        if self.queued_offset == self.queued_interleaved.len() {
+            self.queued_interleaved.clear();
+            self.queued_offset = 0;
+        } else if self.queued_offset >= RUBATO_QUEUE_COMPACT_THRESHOLD
+            && self.queued_offset * 2 >= self.queued_interleaved.len()
+        {
+            self.queued_interleaved.drain(..self.queued_offset);
+            self.queued_offset = 0;
+        }
+        true
+    }
+
+    fn append_output(&mut self, out_frames: usize) {
+        if out_frames == 0 {
+            return;
+        }
+
+        let dropped = self.pending_delay_drop.min(out_frames);
+        self.pending_delay_drop -= dropped;
+        let kept_frames = out_frames - dropped;
+        if kept_frames == 0 {
+            return;
+        }
+
+        self.queued_interleaved
+            .reserve(kept_frames * self.key.output_channels);
+        for frame_idx in dropped..out_frames {
+            for channel in 0..self.key.output_channels {
+                self.queued_interleaved
+                    .push(self.output_buffer[channel][frame_idx]);
+            }
+        }
+    }
+
+    fn process_chunk(
+        &mut self,
+        playback: &PlaybackData,
+        total_frames: usize,
+    ) -> Result<bool, String> {
+        let needed_input_frames = self.resampler.input_frames_next();
+        if self.input_cursor_frame >= total_frames && self.drain_chunks_left == 0 {
+            return Ok(false);
+        }
+
+        for channel in 0..self.key.output_channels {
+            let input_channel = &mut self.input_buffer[channel];
+            if input_channel.len() < needed_input_frames {
+                input_channel.resize(needed_input_frames, 0.);
+            }
+            input_channel[..needed_input_frames].fill(0.);
+        }
+
+        let available_input_frames = total_frames.saturating_sub(self.input_cursor_frame);
+        let copied_input_frames = available_input_frames.min(needed_input_frames);
+        for frame_offset in 0..copied_input_frames {
+            let source_frame_idx = self.input_cursor_frame + frame_offset;
+            for output_channel in 0..self.key.output_channels {
+                self.input_buffer[output_channel][frame_offset] = source_sample_for_output(
+                    playback,
+                    source_frame_idx,
+                    output_channel,
+                    self.key.output_channels,
+                );
+            }
+        }
+        self.input_cursor_frame += copied_input_frames;
+        if self.input_cursor_frame >= total_frames && self.drain_chunks_left == 0 {
+            self.drain_chunks_left = 1;
+        }
+        if copied_input_frames == 0 && self.drain_chunks_left > 0 {
+            self.drain_chunks_left -= 1;
+        }
+
+        let (_, out_frames) = self
+            .resampler
+            .process_into_buffer(&self.input_buffer, &mut self.output_buffer, None)
+            .map_err(|e| format!("rubato process error: {}", e))?;
+        self.append_output(out_frames);
+
+        Ok(self.output_frames_available() > 0
+            || self.input_cursor_frame < total_frames
+            || self.drain_chunks_left > 0)
+    }
+}
+
+#[derive(Default)]
+struct RenderState {
+    rubato_resampler: Option<RubatoStreamResampler>,
+    observed_cursor_version: Option<u64>,
+    frame_buffer: Vec<f32>,
+}
+
+fn source_sample_for_output(
+    playback: &PlaybackData,
+    source_frame_idx: usize,
+    output_channel: usize,
+    output_channels: usize,
+) -> f32 {
+    if playback.input_channels == 0 {
+        return 0.;
+    }
+    let source_offset = source_frame_idx * playback.input_channels;
+    if source_offset >= playback.samples.len() {
+        return 0.;
+    }
+
+    if playback.input_channels == 1 {
+        return playback.samples[source_offset];
+    }
+
+    if output_channels == 1 {
+        let left = playback.samples[source_offset];
+        let right = playback.samples[source_offset + 1.min(playback.input_channels - 1)];
+        return (left + right) * 0.5;
+    }
+
+    let source_channel = if playback.input_channels == 2 {
+        output_channel % 2
+    } else {
+        output_channel.min(playback.input_channels - 1)
+    };
+    playback.samples[source_offset + source_channel]
+}
+
+fn fill_silence<T, F>(data: &mut [T], convert: &F)
+where
+    T: Copy,
+    F: Fn(f32) -> T,
+{
+    for sample in data {
+        *sample = convert(0.);
+    }
+}
+
+fn fill_output_without_resampler<T, F>(
+    data: &mut [T],
+    output_channels: usize,
+    playback: &mut PlaybackData,
+    total_frames: usize,
+    shared: &SharedPlayback,
+    convert: &F,
+) where
+    T: Copy,
+    F: Fn(f32) -> T,
+{
+    let mut reached_end = false;
+    for frame in data.chunks_mut(output_channels) {
+        let source_frame_idx = playback.position_frame.max(0.).floor() as usize;
+        if source_frame_idx >= total_frames {
+            reached_end = true;
+            for sample in frame {
+                *sample = convert(0.);
+            }
+            continue;
+        }
+
+        for (output_channel, sample) in frame.iter_mut().enumerate() {
+            let value = source_sample_for_output(
+                playback,
+                source_frame_idx,
+                output_channel,
+                output_channels,
+            );
+            *sample = convert((value * playback.volume).clamp(-1., 1.));
+        }
+        playback.position_frame = (playback.position_frame + 1.).min(total_frames as f64);
+    }
+
+    if reached_end {
+        playback.position_frame = total_frames as f64;
+        if playback.is_playing {
+            playback.is_playing = false;
+            shared.mark_track_end();
+        }
+    }
+}
+
+fn fill_output_with_rubato<T, F>(
+    data: &mut [T],
+    output_channels: usize,
+    output_sample_rate: u32,
+    playback: &mut PlaybackData,
+    total_frames: usize,
+    render_state: &mut RenderState,
+    shared: &SharedPlayback,
+    convert: &F,
+) where
+    T: Copy,
+    F: Fn(f32) -> T,
+{
+    let mut cursor_changed = render_state.observed_cursor_version != Some(playback.cursor_version);
+    render_state.observed_cursor_version = Some(playback.cursor_version);
+
+    let needs_new_resampler = match render_state.rubato_resampler.as_ref() {
+        Some(resampler) => {
+            !resampler.matches(playback.sample_rate, output_sample_rate, output_channels)
+        }
+        None => true,
+    };
+    if needs_new_resampler {
+        match RubatoStreamResampler::new(playback.sample_rate, output_sample_rate, output_channels)
+        {
+            Ok(resampler) => {
+                render_state.rubato_resampler = Some(resampler);
+                cursor_changed = true;
+            }
+            Err(err) => {
+                log::error!("{}", err);
+                playback.is_playing = false;
+                shared.mark_stream_error(err);
+                fill_silence(data, convert);
+                return;
+            }
+        }
+    }
+
+    let resampler = render_state.rubato_resampler.as_mut().unwrap();
+    if cursor_changed {
+        resampler.reset_for_cursor(playback.position_frame);
+    }
+    if render_state.frame_buffer.len() < output_channels {
+        render_state.frame_buffer.resize(output_channels, 0.);
+    }
+
+    let step = playback.sample_rate as f64 / output_sample_rate as f64;
+    let mut reached_end = false;
+    let mut process_error: Option<(usize, String)> = None;
+
+    for (frame_idx, frame) in data.chunks_mut(output_channels).enumerate() {
+        let mut has_frame = resampler.read_frame(&mut render_state.frame_buffer[..output_channels]);
+        let mut can_generate = true;
+        let mut attempts = 0;
+        while !has_frame && can_generate && attempts < RUBATO_MAX_GENERATE_ATTEMPTS {
+            attempts += 1;
+            match resampler.process_chunk(playback, total_frames) {
+                Ok(has_more) => {
+                    can_generate = has_more;
+                }
+                Err(err) => {
+                    process_error = Some((frame_idx, err));
+                    break;
+                }
+            }
+            has_frame = resampler.read_frame(&mut render_state.frame_buffer[..output_channels]);
+        }
+
+        if process_error.is_some() {
+            break;
+        }
+
+        if !has_frame {
+            reached_end = true;
+            for sample in frame {
+                *sample = convert(0.);
+            }
+            continue;
+        }
+
+        for (output_channel, sample) in frame.iter_mut().enumerate() {
+            let value =
+                (render_state.frame_buffer[output_channel] * playback.volume).clamp(-1., 1.);
+            *sample = convert(value);
+        }
+        playback.position_frame = (playback.position_frame + step).min(total_frames as f64);
+    }
+
+    if let Some((failed_frame_idx, err)) = process_error {
+        log::error!("{}", err);
+        playback.is_playing = false;
+        shared.mark_stream_error(err);
+        let start = failed_frame_idx * output_channels;
+        fill_silence(&mut data[start..], convert);
+        return;
+    }
+
+    if reached_end {
+        playback.position_frame = total_frames as f64;
+        if playback.is_playing {
+            playback.is_playing = false;
+            shared.mark_track_end();
+        }
+    }
+}
+
+fn fill_output<T, F>(
+    data: &mut [T],
+    output_channels: usize,
+    output_sample_rate: u32,
+    shared: &SharedPlayback,
+    render_state: &mut RenderState,
+    convert: F,
+) where
+    T: Copy,
+    F: Fn(f32) -> T,
+{
+    let mut playback = shared.data.lock();
+
+    if output_channels == 0 || output_sample_rate == 0 {
+        return;
+    }
+
+    if !playback.is_playing
+        || playback.samples.is_empty()
+        || playback.input_channels == 0
+        || playback.sample_rate == 0
+    {
+        fill_silence(data, &convert);
+        return;
+    }
+
+    let total_frames = playback.samples.len() / playback.input_channels;
+    if total_frames == 0 {
+        playback.is_playing = false;
+        playback.position_frame = 0.;
+        shared.mark_track_end();
+        fill_silence(data, &convert);
+        return;
+    }
+
+    if playback.sample_rate == output_sample_rate {
+        render_state.rubato_resampler = None;
+        fill_output_without_resampler(
+            data,
+            output_channels,
+            &mut playback,
+            total_frames,
+            shared,
+            &convert,
+        );
+        return;
+    }
+
+    fill_output_with_rubato(
+        data,
+        output_channels,
+        output_sample_rate,
+        &mut playback,
+        total_frames,
+        render_state,
+        shared,
+        &convert,
+    );
+}
+
+fn build_output_stream(
+    shared: &Arc<SharedPlayback>,
+    requested_sr: Option<u32>,
+) -> Result<OutputStreamState, String> {
+    let device = default_output_device()?;
+    let current_device_name =
+        device_name(&device).unwrap_or_else(|| "<unknown-device>".to_string());
+
+    let (config, sample_format, selected_sr) = choose_stream_config(&device, requested_sr)?;
+    let output_channels = config.channels as usize;
+
+    let shared_for_error = Arc::clone(shared);
+    let err_fn = move |err: cpal::StreamError| {
+        log::error!("audio stream error: {}", err);
+        shared_for_error.mark_stream_error(err.to_string());
+    };
+
+    let stream = match sample_format {
+        SampleFormat::F32 => {
+            let shared = Arc::clone(shared);
+            let mut render_state = RenderState::default();
+            device.build_output_stream(
+                &config,
+                move |data: &mut [f32], _| {
+                    fill_output(
+                        data,
+                        output_channels,
+                        selected_sr,
+                        &shared,
+                        &mut render_state,
+                        |x| x,
+                    );
+                },
+                err_fn,
+                None,
+            )
+        }
+        SampleFormat::I16 => {
+            let shared = Arc::clone(shared);
+            let mut render_state = RenderState::default();
+            device.build_output_stream(
+                &config,
+                move |data: &mut [i16], _| {
+                    fill_output(
+                        data,
+                        output_channels,
+                        selected_sr,
+                        &shared,
+                        &mut render_state,
+                        |x| (x * i16::MAX as f32) as i16,
+                    );
+                },
+                err_fn,
+                None,
+            )
+        }
+        SampleFormat::U16 => {
+            let shared = Arc::clone(shared);
+            let mut render_state = RenderState::default();
+            device.build_output_stream(
+                &config,
+                move |data: &mut [u16], _| {
+                    fill_output(
+                        data,
+                        output_channels,
+                        selected_sr,
+                        &shared,
+                        &mut render_state,
+                        |x| ((x * 0.5 + 0.5) * u16::MAX as f32) as u16,
+                    );
+                },
+                err_fn,
+                None,
+            )
+        }
+        _ => {
+            return Err(format!(
+                "Unsupported output sample format from device: {:?}",
+                sample_format
+            ));
+        }
+    }
+    .map_err(|e| format!("Failed to build output stream: {}", e))?;
+
+    stream
+        .play()
+        .map_err(|e| format!("Failed to start output stream: {}", e))?;
+
+    log::info!(
+        "device: {}, sr: {}, channels: {}, format: {:?}",
+        current_device_name,
+        selected_sr,
+        output_channels,
+        sample_format
+    );
+
+    Ok(OutputStreamState {
+        _stream: stream,
+        device_name: current_device_name,
+    })
+}
+
+pub(super) fn rebuild_stream(
+    shared: &Arc<SharedPlayback>,
+    requested_sr: Option<u32>,
+    stream_state: &mut Option<OutputStreamState>,
+    current_error: &mut String,
+) -> bool {
+    match build_output_stream(shared, requested_sr) {
+        Ok(new_stream_state) => {
+            *stream_state = Some(new_stream_state);
+            set_error(current_error, None)
+        }
+        Err(err_str) => {
+            log::error!("{}", err_str);
+            *stream_state = None;
+            let mut playback = shared.data.lock();
+            playback.is_playing = false;
+            set_error(current_error, Some(err_str))
+        }
+    }
+}

--- a/src-tauri/src/player/stream.rs
+++ b/src-tauri/src/player/stream.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use audioadapter_buffers::direct::SequentialSliceOfVecs;
 use cpal::traits::{DeviceTrait, StreamTrait};
 use cpal::{Sample, SampleFormat, Stream};
 use rubato::{
-    Resampler, SincFixedOut, SincInterpolationParameters, SincInterpolationType, WindowFunction,
-    calculate_cutoff,
+    Async, FixedAsync, Resampler, SincInterpolationParameters, SincInterpolationType,
+    WindowFunction, calculate_cutoff,
 };
 
 use super::device::{choose_stream_config, default_output_device, device_name};
@@ -31,7 +32,7 @@ struct RubatoConfigKey {
 
 struct RubatoStreamResampler {
     key: RubatoConfigKey,
-    resampler: SincFixedOut<f32>,
+    resampler: Async<f32>,
     input_buffer: Vec<Vec<f32>>,
     output_buffer: Vec<Vec<f32>>,
     queued_interleaved: Vec<f32>,
@@ -62,12 +63,18 @@ impl RubatoStreamResampler {
             oversampling_factor: RUBATO_OVERSAMPLING,
             window: RUBATO_WINDOW,
         };
-        let resampler =
-            SincFixedOut::<f32>::new(ratio, 1.0, params, RUBATO_CHUNK_SIZE, output_channels)
-                .map_err(|e| format!("Failed to build rubato resampler: {}", e))?;
+        let resampler = Async::<f32>::new_sinc(
+            ratio,
+            1.0,
+            &params,
+            RUBATO_CHUNK_SIZE,
+            output_channels,
+            FixedAsync::Output,
+        )
+        .map_err(|e| format!("Failed to build rubato resampler: {}", e))?;
         let pending_delay_drop = resampler.output_delay();
-        let input_buffer = resampler.input_buffer_allocate(true);
-        let output_buffer = resampler.output_buffer_allocate(true);
+        let input_buffer = vec![vec![0.; resampler.input_frames_max()]; output_channels];
+        let output_buffer = vec![vec![0.; resampler.output_frames_max()]; output_channels];
 
         Ok(Self {
             key: RubatoConfigKey {
@@ -165,12 +172,13 @@ impl RubatoStreamResampler {
         playback: &PlaybackData,
         total_frames: usize,
     ) -> Result<bool, String> {
-        let needed_input_frames = self.resampler.input_frames_next();
         if self.input_cursor_frame >= total_frames && self.drain_chunks_left == 0 {
             return Ok(false);
         }
+        let output_channels = self.key.output_channels;
+        let needed_input_frames = self.resampler.input_frames_next();
 
-        for channel in 0..self.key.output_channels {
+        for channel in 0..output_channels {
             let input_channel = &mut self.input_buffer[channel];
             if input_channel.len() < needed_input_frames {
                 input_channel.resize(needed_input_frames, 0.);
@@ -182,12 +190,12 @@ impl RubatoStreamResampler {
         let copied_input_frames = available_input_frames.min(needed_input_frames);
         for frame_offset in 0..copied_input_frames {
             let source_frame_idx = self.input_cursor_frame + frame_offset;
-            for output_channel in 0..self.key.output_channels {
+            for output_channel in 0..output_channels {
                 self.input_buffer[output_channel][frame_offset] = source_sample_for_output(
                     playback,
                     source_frame_idx,
                     output_channel,
-                    self.key.output_channels,
+                    output_channels,
                 );
             }
         }
@@ -199,9 +207,22 @@ impl RubatoStreamResampler {
             self.drain_chunks_left -= 1;
         }
 
+        let output_frames_capacity = self.output_buffer.first().map_or(0, Vec::len);
+        let input_adapter = SequentialSliceOfVecs::new(
+            self.input_buffer.as_slice(),
+            output_channels,
+            needed_input_frames,
+        )
+        .map_err(|e| format!("rubato input adapter error: {}", e))?;
+        let mut output_adapter = SequentialSliceOfVecs::new_mut(
+            self.output_buffer.as_mut_slice(),
+            output_channels,
+            output_frames_capacity,
+        )
+        .map_err(|e| format!("rubato output adapter error: {}", e))?;
         let (_, out_frames) = self
             .resampler
-            .process_into_buffer(&self.input_buffer, &mut self.output_buffer, None)
+            .process_into_buffer(&input_adapter, &mut output_adapter, None)
             .map_err(|e| format!("rubato process error: {}", e))?;
         self.append_output(out_frames);
 

--- a/src-tauri/src/player/stream.rs
+++ b/src-tauri/src/player/stream.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use cpal::traits::{DeviceTrait, StreamTrait};
-use cpal::{SampleFormat, Stream};
+use cpal::{Sample, SampleFormat, Stream};
 use rubato::{
     Resampler, SincFixedOut, SincInterpolationParameters, SincInterpolationType, WindowFunction,
     calculate_cutoff,
@@ -519,7 +519,7 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| (x * i16::MAX as f32) as i16,
+                        |x| <i16 as Sample>::from_sample(x),
                     );
                 },
                 err_fn,
@@ -538,7 +538,45 @@ fn build_output_stream(
                         selected_sr,
                         &shared,
                         &mut render_state,
-                        |x| ((x * 0.5 + 0.5) * u16::MAX as f32) as u16,
+                        |x| <u16 as Sample>::from_sample(x),
+                    );
+                },
+                err_fn,
+                None,
+            )
+        }
+        SampleFormat::I24 => {
+            let shared = Arc::clone(shared);
+            let mut render_state = RenderState::default();
+            device.build_output_stream(
+                &config,
+                move |data: &mut [cpal::I24], _| {
+                    fill_output(
+                        data,
+                        output_channels,
+                        selected_sr,
+                        &shared,
+                        &mut render_state,
+                        |x| <cpal::I24 as Sample>::from_sample(x),
+                    );
+                },
+                err_fn,
+                None,
+            )
+        }
+        SampleFormat::U24 => {
+            let shared = Arc::clone(shared);
+            let mut render_state = RenderState::default();
+            device.build_output_stream(
+                &config,
+                move |data: &mut [cpal::U24], _| {
+                    fill_output(
+                        data,
+                        output_channels,
+                        selected_sr,
+                        &shared,
+                        &mut render_state,
+                        |x| <cpal::U24 as Sample>::from_sample(x),
                     );
                 },
                 err_fn,

--- a/src-wasm/Cargo.toml
+++ b/src-wasm/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 approx = { workspace = true }
+audioadapter-buffers = { workspace = true }
 atomic_float = { workspace = true }
 chrono = "0.4.42"
 fast_image_resize = "5.3.0"

--- a/src-wasm/Cargo.toml
+++ b/src-wasm/Cargo.toml
@@ -19,7 +19,7 @@ js-sys = "0.3.82"
 ndarray = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
-rubato = "0.16.2"
+rubato = { workspace = true }
 serde-wasm-bindgen = "0.6.5"
 thesia-common = { path = "../src-common" }
 wasm-bindgen = "0.2.105"

--- a/src-wasm/src/resample.rs
+++ b/src-wasm/src/resample.rs
@@ -76,3 +76,142 @@ pub(crate) fn resample(wav: &[f32], sr: u32, output_sr: u32) -> Vec<f32> {
         resampled
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    fn clear_resamplers() {
+        RESAMPLERS.with_borrow_mut(|resamplers| resamplers.clear());
+    }
+
+    fn impulse(len: usize, index: usize) -> Vec<f32> {
+        let mut signal = vec![0.0; len];
+        signal[index] = 1.0;
+        signal
+    }
+
+    fn peak_index(signal: &[f32]) -> usize {
+        signal
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.abs().total_cmp(&b.abs()))
+            .map(|(index, _)| index)
+            .unwrap()
+    }
+
+    fn expected_index(input_index: usize, sr: u32, output_sr: u32) -> usize {
+        (input_index as f64 * output_sr as f64 / sr as f64).round() as usize
+    }
+
+    fn make_test_signal(len: usize, sr: u32) -> Vec<f32> {
+        (0..len)
+            .map(|i| {
+                let t = i as f32 / sr as f32;
+                // Keep energy away from Nyquist so round-trip error reflects resampler quality.
+                0.55 * (2.0 * PI * 220.0 * t).sin()
+                    + 0.30 * (2.0 * PI * 880.0 * t).sin()
+                    + 0.15 * (2.0 * PI * 3200.0 * t).sin()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn resample_has_no_extra_lag_for_impulse() {
+        clear_resamplers();
+
+        let input_len = UPSAMPLE_CHUNK_SIZE * 4 + 77;
+        let input_impulse_index = UPSAMPLE_CHUNK_SIZE + 37;
+        let sample_rate_pairs = [
+            (44_100, 44_100),
+            (44_100, 48_000),
+            (48_000, 44_100),
+            (22_050, 48_000),
+            (96_000, 44_100),
+        ];
+
+        for (sr, output_sr) in sample_rate_pairs {
+            let output = resample(&impulse(input_len, input_impulse_index), sr, output_sr);
+            let actual_peak = peak_index(&output);
+            let expected_peak = expected_index(input_impulse_index, sr, output_sr);
+
+            assert!(
+                actual_peak.abs_diff(expected_peak) <= 1,
+                "unexpected lag for {sr}->{output_sr}: expected impulse near {expected_peak}, got {actual_peak}"
+            );
+        }
+    }
+
+    #[test]
+    fn resample_keeps_zero_index_impulse_at_zero() {
+        clear_resamplers();
+
+        let input = impulse(UPSAMPLE_CHUNK_SIZE * 4, 0);
+        let output = resample(&input, 44_100, 48_000);
+        let peak = peak_index(&output);
+
+        assert_eq!(peak, 0, "resampler introduced leading lag at signal start");
+    }
+
+    #[test]
+    fn round_trip_up_and_down_matches_original_closely() {
+        clear_resamplers();
+
+        let source_sr = 44_100;
+        let upsampled_sr = 48_000;
+        let source = make_test_signal(UPSAMPLE_CHUNK_SIZE * 8 + 73, source_sr);
+
+        let upsampled = resample(&source, source_sr, upsampled_sr);
+        let round_tripped = resample(&upsampled, upsampled_sr, source_sr);
+
+        assert_eq!(
+            round_tripped.len(),
+            source.len(),
+            "round-trip output length changed unexpectedly"
+        );
+
+        // Ignore boundaries where zero-padding/flush effects are strongest.
+        let edge = 256usize;
+        let compare_len = source.len().saturating_sub(edge * 2);
+        assert!(
+            compare_len > 0,
+            "test signal too short for round-trip check"
+        );
+
+        let source_mid = &source[edge..edge + compare_len];
+        let round_tripped_mid = &round_tripped[edge..edge + compare_len];
+
+        let mut abs_error_sum = 0.0f32;
+        let mut max_abs_error = 0.0f32;
+
+        for (&orig, &rt) in source_mid.iter().zip(round_tripped_mid.iter()) {
+            let abs_err = (orig - rt).abs();
+            abs_error_sum += abs_err;
+            max_abs_error = max_abs_error.max(abs_err);
+        }
+
+        let mae = abs_error_sum / compare_len as f32;
+
+        assert!(
+            mae < 1.0e-4,
+            "round-trip mean absolute error too high: mae={mae}, max_abs_error={max_abs_error}"
+        );
+        assert!(
+            max_abs_error < 1.0e-3,
+            "round-trip max absolute error too high: mae={mae}, max_abs_error={max_abs_error}"
+        );
+    }
+
+    #[test]
+    fn resample_empty_input_returns_empty_output() {
+        clear_resamplers();
+
+        let output = resample(&[], 44_100, 48_000);
+        assert!(
+            output.is_empty(),
+            "empty input should produce empty output, got len={}",
+            output.len()
+        );
+    }
+}

--- a/src-wasm/src/resample.rs
+++ b/src-wasm/src/resample.rs
@@ -1,11 +1,12 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use rubato::{FftFixedInOut, Resampler};
+use audioadapter_buffers::direct::SequentialSlice;
+use rubato::{Fft, FixedSync, Resampler};
 
 const UPSAMPLE_CHUNK_SIZE: usize = 1024;
 
-type ResamplerWithBuffers = (FftFixedInOut<f32>, Vec<f32>, Vec<f32>);
+type ResamplerWithBuffers = (Fft<f32>, Vec<f32>, Vec<f32>);
 
 thread_local! {
     static RESAMPLERS: RefCell<HashMap<(u32, u32), ResamplerWithBuffers>> =
@@ -13,20 +14,26 @@ thread_local! {
 }
 
 pub(crate) fn resample(wav: &[f32], sr: u32, output_sr: u32) -> Vec<f32> {
+    if wav.is_empty() {
+        return Vec::new();
+    }
+
     let output_len = (wav.len() as f64 * output_sr as f64 / sr as f64).round() as usize;
 
     RESAMPLERS.with_borrow_mut(|resamplers| {
         resamplers.retain(|key, _| !(key.0 == sr && key.1 > output_sr * 2));
         let (resampler, in_buffer, out_buffer) =
             resamplers.entry((sr, output_sr)).or_insert_with(|| {
-                let resampler = FftFixedInOut::<f32>::new(
+                let resampler = Fft::<f32>::new(
                     sr as usize,
                     output_sr as usize,
                     UPSAMPLE_CHUNK_SIZE,
                     1,
+                    1,
+                    FixedSync::Input,
                 )
                 .unwrap();
-                let in_buffer = Vec::with_capacity(resampler.input_frames_max());
+                let in_buffer = vec![0.; resampler.input_frames_max()];
                 let out_buffer = vec![0.; resampler.output_frames_max()];
                 (resampler, in_buffer, out_buffer)
             });
@@ -34,44 +41,62 @@ pub(crate) fn resample(wav: &[f32], sr: u32, output_sr: u32) -> Vec<f32> {
         let mut resampled = Vec::with_capacity(delay + output_len + output_sr as usize / 100);
 
         {
-            let mut wave_out = [out_buffer.as_mut_slice()];
-
             // process frames in chunks
             let mut i = 0;
             while i + resampler.input_frames_next() <= wav.len() {
-                let wave_in = [&wav[i..i + resampler.input_frames_next()]];
+                let input_frames = resampler.input_frames_next();
+                let wave_in =
+                    SequentialSlice::new(&wav[i..i + input_frames], 1, input_frames).unwrap();
+                let out_frames_capacity = out_buffer.len();
+                let mut wave_out =
+                    SequentialSlice::new_mut(out_buffer.as_mut_slice(), 1, out_frames_capacity)
+                        .unwrap();
                 let (in_frame_len, out_frame_len) = resampler
                     .process_into_buffer(&wave_in, &mut wave_out, None)
                     .unwrap();
-                resampled.extend_from_slice(&wave_out[0][..out_frame_len]);
+                resampled.extend_from_slice(&out_buffer[..out_frame_len]);
                 i += in_frame_len;
             }
 
             // process remaining frames
             if i < wav.len() {
-                in_buffer.extend_from_slice(&wav[i..]);
-                in_buffer.resize(resampler.input_frames_next(), 0.0);
-                let wave_in = [in_buffer.as_slice()];
+                let input_frames = resampler.input_frames_next();
+                let remaining = wav.len() - i;
+                in_buffer[..remaining].copy_from_slice(&wav[i..]);
+                in_buffer[remaining..input_frames].fill(0.);
+                let wave_in =
+                    SequentialSlice::new(&in_buffer[..input_frames], 1, input_frames).unwrap();
+                let out_frames_capacity = out_buffer.len();
+                let mut wave_out =
+                    SequentialSlice::new_mut(out_buffer.as_mut_slice(), 1, out_frames_capacity)
+                        .unwrap();
                 let (_, out_frame_len) = resampler
                     .process_into_buffer(&wave_in, &mut wave_out, None)
                     .unwrap();
-                resampled.extend_from_slice(&wave_out[0][..out_frame_len]);
+                resampled.extend_from_slice(&out_buffer[..out_frame_len]);
             }
 
             // flush the last frame
-            in_buffer.resize(resampler.input_frames_next(), 0.0);
-            let wave_in = [in_buffer.as_slice()];
+            let input_frames = resampler.input_frames_next();
+            in_buffer[..input_frames].fill(0.);
+            let wave_in =
+                SequentialSlice::new(&in_buffer[..input_frames], 1, input_frames).unwrap();
+            let out_frames_capacity = out_buffer.len();
+            let mut wave_out =
+                SequentialSlice::new_mut(out_buffer.as_mut_slice(), 1, out_frames_capacity)
+                    .unwrap();
             let (_, out_frame_len) = resampler
                 .process_into_buffer(&wave_in, &mut wave_out, None)
                 .unwrap();
-            resampled.extend_from_slice(&wave_out[0][..out_frame_len]);
+            resampled.extend_from_slice(&out_buffer[..out_frame_len]);
         }
 
         resampler.reset();
-        in_buffer.clear();
+        in_buffer.fill(0.);
         out_buffer.fill(0.0);
 
-        resampled.drain(..delay);
+        let drop_len = delay.min(resampled.len());
+        resampled.drain(..drop_len);
         resampled.truncate(output_len);
         resampled
     })

--- a/src/api/backend-listeners.ts
+++ b/src/api/backend-listeners.ts
@@ -1,5 +1,5 @@
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
-import { AxisKind } from "./backend-wrapper";
+import { AxisKind, PlayerState } from "./backend-wrapper";
 
 export async function listenOpenFiles(
   handler: (files: string[]) => void | Promise<void>,
@@ -45,6 +45,14 @@ export async function listenMenuSelectAllTracks(
   handler: () => void | Promise<void>,
 ): Promise<UnlistenFn> {
   return listen("select-all-tracks", handler);
+}
+
+export async function listenPlayerStateChanged(
+  handler: (state: PlayerState) => void | Promise<void>,
+): Promise<UnlistenFn> {
+  return listen<PlayerState>("player-state-changed", (event) => {
+    handler(event.payload);
+  });
 }
 
 export async function listenTogglePlay(handler: () => void | Promise<void>): Promise<UnlistenFn> {

--- a/src/api/backend-wrapper.ts
+++ b/src/api/backend-wrapper.ts
@@ -32,6 +32,8 @@ export type NormalizeTarget =
 export interface PlayerState {
   isPlaying: boolean;
   positionSec: number;
+  eventTimeMs: number;
+  trackId: number | null;
   err: string;
 }
 
@@ -116,10 +118,6 @@ export async function getGuardClipStats(trackId: number): Promise<[number, strin
   // [channel, stats]
   // if [[-1, stats]], then all channels have the same stats
   return invoke<[number, string][]>("get_guard_clip_stats", { trackId });
-}
-
-export async function getPlayerState(): Promise<PlayerState> {
-  return invoke<PlayerState>("get_player_state");
 }
 
 export async function init(colormapLength: number): Promise<ConstsAndUserSettings> {

--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -2,7 +2,12 @@ import { RefObject, useContext, useEffect, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import { useHotkeys } from "react-hotkeys-hook";
 import BackendAPI from "../api";
-import { listenJumpPlayer, listenRewindToFront, listenTogglePlay } from "../api";
+import {
+  listenJumpPlayer,
+  listenPlayerStateChanged,
+  listenRewindToFront,
+  listenTogglePlay,
+} from "../api";
 import { BackendConstantsContext } from "../contexts";
 
 export type Player = {
@@ -18,46 +23,89 @@ export type Player = {
 
 function usePlayer(selectedTrackId: number, maxTrackSec: number) {
   const { PLAY_JUMP_SEC, PLAY_BIG_JUMP_SEC } = useContext(BackendConstantsContext);
+  const TRACK_SWITCH_SEEK_TTL_MS = 1000;
   const [currentPlayingTrack, setCurrentPlayingTrack] = useState<number>(-1);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const deviceErrorRef = useRef<string | null>(null);
 
   const positionSecRef = useRef<number>(0);
+  const anchorPositionSecRef = useRef<number>(0);
+  const anchorEventTimeMsRef = useRef<number>(0);
+  const pendingTrackStartSecRef = useRef<number | null>(null);
+  const pendingTrackStartEventMsRef = useRef<number>(0);
   const selectSecRef = useRef<number>(0);
   const setSelectSec = useEvent((sec: number) => {
     selectSecRef.current = Math.min(Math.max(sec, 0), maxTrackSec);
   });
 
   const requestRef = useRef<number>(0);
-  const updatePlayerStatesRef = useRef<(() => Promise<void>) | null>(null);
+  const updatePositionRef = useRef<(() => void) | null>(null);
 
-  const updatePlayerStates = useEvent(async () => {
-    // const start = performance.now();
-    const { isPlaying: newIsPlaying, positionSec, err } = await BackendAPI.getPlayerState();
-    // const end = performance.now();
-    // console.log(`Execution time: ${end - start} ms`);
-    if (err) {
-      if (deviceErrorRef.current === null) console.error(err);
-      deviceErrorRef.current = err;
-    } else {
-      if (deviceErrorRef.current !== null) console.log("Error resolved");
-      deviceErrorRef.current = null;
+  const updatePosition = useEvent(() => {
+    let positionSec = anchorPositionSecRef.current;
+    if (isPlaying) {
+      const elapsedSec = Math.max(0, Date.now() - anchorEventTimeMsRef.current) / 1000;
+      positionSec += elapsedSec;
     }
-    if (isPlaying !== newIsPlaying) setIsPlaying(newIsPlaying);
-    positionSecRef.current = positionSec;
-    if (updatePlayerStatesRef.current)
-      requestRef.current = requestAnimationFrame(updatePlayerStatesRef.current);
+    positionSecRef.current = Math.min(Math.max(positionSec, 0), maxTrackSec);
+    if (updatePositionRef.current) requestRef.current = requestAnimationFrame(updatePositionRef.current);
   });
 
   useEffect(() => {
-    updatePlayerStatesRef.current = updatePlayerStates;
-    requestRef.current = requestAnimationFrame(updatePlayerStatesRef.current);
+    updatePositionRef.current = updatePosition;
+    requestRef.current = requestAnimationFrame(updatePositionRef.current);
     return () => cancelAnimationFrame(requestRef.current);
-  }, [updatePlayerStates]);
+  }, [updatePosition]);
+
+  useEffect(() => {
+    const promiseUnlisten = listenPlayerStateChanged(
+      ({ isPlaying: nextIsPlaying, positionSec, eventTimeMs, err }) => {
+        const clampedPositionSec = Math.min(Math.max(positionSec, 0), maxTrackSec);
+        anchorPositionSecRef.current = clampedPositionSec;
+        anchorEventTimeMsRef.current = Number.isFinite(eventTimeMs) ? eventTimeMs : Date.now();
+        positionSecRef.current = clampedPositionSec;
+        setIsPlaying(nextIsPlaying);
+
+        if (err) {
+          if (deviceErrorRef.current === null) console.error(err);
+          deviceErrorRef.current = err;
+        } else {
+          if (deviceErrorRef.current !== null) console.log("Error resolved");
+          deviceErrorRef.current = null;
+        }
+      },
+    );
+    return () => {
+      promiseUnlisten.then((unlistenFn) => unlistenFn());
+    };
+  }, [maxTrackSec]);
+
+  const seek = useEvent(async (sec: number) => {
+    const clampedSec = Math.min(Math.max(sec, 0), maxTrackSec);
+    pendingTrackStartSecRef.current = clampedSec;
+    pendingTrackStartEventMsRef.current = Date.now();
+    await BackendAPI.seekPlayer(clampedSec);
+  });
 
   const setPlayingTrack = useEvent(async (trackId: number) => {
     if (trackId === currentPlayingTrack || trackId < 0) return;
-    await BackendAPI.setTrackPlayer(trackId);
+
+    const now = Date.now();
+    const pendingSec = pendingTrackStartSecRef.current;
+    const usePendingSec =
+      pendingSec !== null && now - pendingTrackStartEventMsRef.current <= TRACK_SWITCH_SEEK_TTL_MS;
+
+    let startSec = usePendingSec ? pendingSec : selectSecRef.current;
+    if (!usePendingSec && isPlaying) {
+      const elapsedSec = Math.max(0, now - anchorEventTimeMsRef.current) / 1000;
+      startSec = anchorPositionSecRef.current + elapsedSec;
+    }
+    startSec = Math.min(Math.max(startSec, 0), maxTrackSec);
+
+    pendingTrackStartSecRef.current = null;
+    pendingTrackStartEventMsRef.current = 0;
+
+    await BackendAPI.setTrackPlayer(trackId, startSec);
     setCurrentPlayingTrack(trackId);
   });
 
@@ -65,7 +113,7 @@ function usePlayer(selectedTrackId: number, maxTrackSec: number) {
     if (isPlaying) {
       await BackendAPI.pausePlayer();
     } else if (selectedTrackId >= 0) {
-      await BackendAPI.seekPlayer(selectSecRef.current);
+      await seek(selectSecRef.current);
       await BackendAPI.resumePlayer();
     }
   });
@@ -93,7 +141,7 @@ function usePlayer(selectedTrackId: number, maxTrackSec: number) {
 
   const jump = useEvent(async (jumpSec: number) => {
     if (isPlaying) {
-      await BackendAPI.seekPlayer((positionSecRef.current ?? 0) + jumpSec);
+      await seek((positionSecRef.current ?? 0) + jumpSec);
       return;
     }
     setSelectSec((selectSecRef.current ?? 0) + jumpSec);
@@ -131,7 +179,7 @@ function usePlayer(selectedTrackId: number, maxTrackSec: number) {
   }, [jump, PLAY_JUMP_SEC, PLAY_BIG_JUMP_SEC]);
 
   const rewindToFront = useEvent(async () => {
-    if (isPlaying) await BackendAPI.seekPlayer(0);
+    if (isPlaying) await seek(0);
     else setSelectSec(0);
   });
   useHotkeys("enter", rewindToFront, { preventDefault: true }, [rewindToFront]);
@@ -152,7 +200,7 @@ function usePlayer(selectedTrackId: number, maxTrackSec: number) {
     selectSecRef,
     setSelectSec,
     togglePlay,
-    seek: BackendAPI.seekPlayer,
+    seek,
     jump,
     rewindToFront,
   } as Player;


### PR DESCRIPTION
## Changes
- Rewrote the player backend to use `cpal 0.17.3` directly (removed `kittyaudio`)
- Split player implementation into `player.rs`, `player/device.rs`, `player/state.rs`, and `player/stream.rs`
- Replaced polling-based player state sync (`get_player_state`) with event-based sync via `player-state-changed`
- Updated frontend `usePlayer` to consume backend events and interpolate position locally
- Upgraded workspace `rubato` from `0.16.2` to `1.0.1`
- Migrated streaming resampler integration to the `rubato 1.0.1` API: use `rubato::Async` (`FixedAsync::Output`) in `src-tauri/src/player/stream.rs`
- Migrated WASM resampler integration to the `rubato 1.0.1` API: use `rubato::Fft` (`FixedSync::Input`) in `src-wasm/src/resample.rs`
- Added `audioadapter-buffers` and adapted `process_into_buffer` calls through sequential adapters
- Added `I24`/`U24` output format support and unified sample conversion (`i16`/`u16` included) with `from_sample`
- Switched track audio access from `interleaved_frames` to `interleaved_samples`